### PR TITLE
Use runc prestart hook to execute bpm pre_start

### DIFF
--- a/src/bpm/main_test.go
+++ b/src/bpm/main_test.go
@@ -258,14 +258,12 @@ var _ = Describe("bpm", func() {
 
 		Context("when a pre_start hook is specified", func() {
 			BeforeEach(func() {
-				f, err := os.OpenFile(filepath.Join(boshConfigPath, "pre-start"), os.O_CREATE|os.O_RDWR, 0700)
+				f, err := os.OpenFile(filepath.Join(boshConfigPath, "pre-start"), os.O_CREATE|os.O_RDWR, 0755)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = f.Write([]byte(`
-					#!/bin/bash
-
-					echo "Pre Start executed"
-				`))
+				_, err = f.Write([]byte(fmt.Sprintf(`#!/bin/bash
+					echo "Pre Start executed" > %s
+				`, stdoutFileLocation)))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(f.Close()).To(Succeed())
 

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -117,6 +117,16 @@ func (a *RuncAdapter) BuildSpec(
 		NoNewPrivileges: true,
 	}
 
+	hooks := &specs.Hooks{}
+	if procCfg.Hooks != nil {
+		hooks.Prestart = []specs.Hook{
+			{
+				Path: procCfg.Hooks.PreStart,
+				Env:  processEnvironment(procCfg.Env, bpmCfg),
+			},
+		}
+	}
+
 	mountStore, err := checkDirExists(filepath.Dir(bpmCfg.StoreDir()))
 	if err != nil {
 		return specs.Spec{}, err
@@ -167,6 +177,7 @@ func (a *RuncAdapter) BuildSpec(
 	return specs.Spec{
 		Version: specs.Version,
 		Process: process,
+		Hooks:   hooks,
 		Root: &specs.Root{
 			Path: bpmCfg.RootFSPath(),
 		},

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -346,6 +346,30 @@ var _ = Describe("RuncAdapter", func() {
 			))
 		})
 
+		Context("when the process config has a pre-start hook", func() {
+			BeforeEach(func() {
+				procCfg.Hooks = &config.Hooks{
+					PreStart: "/foobar",
+				}
+			})
+
+			It("adds a prestart hook to the runc spec", func() {
+				spec, err := runcAdapter.BuildSpec(bpmCfg, procCfg, user)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(spec.Hooks).To(Equal(&specs.Hooks{
+					Prestart: []specs.Hook{{
+						Path: "/foobar",
+						Env: append(
+							procCfg.Env,
+							fmt.Sprintf("TMPDIR=%s", bpmCfg.TempDir()),
+							fmt.Sprintf("BPM_ID=%s", bpmCfg.ContainerID()),
+						),
+					}},
+				}))
+			})
+		})
+
 		Context("when there is a persistent store", func() {
 			BeforeEach(func() {
 				Expect(os.MkdirAll(filepath.Join(systemRoot, "store"), 0700)).To(Succeed())

--- a/src/bpm/runc/lifecycle/lifecycle.go
+++ b/src/bpm/runc/lifecycle/lifecycle.go
@@ -119,17 +119,6 @@ func (j *RuncLifecycle) StartJob(bpmCfg *config.BPMConfig, procCfg *config.Proce
 		return fmt.Errorf("bundle build failure: %s", err.Error())
 	}
 
-	if procCfg.Hooks != nil {
-		preStartCmd := exec.Command("/bin/bash", "-c", procCfg.Hooks.PreStart)
-		preStartCmd.Stdout = stdout
-		preStartCmd.Stderr = stderr
-
-		err := j.commandRunner.Run(preStartCmd)
-		if err != nil {
-			return fmt.Errorf("prestart hook failed: %s", err.Error())
-		}
-	}
-
 	return j.runcClient.RunContainer(
 		bpmCfg.PidFile(),
 		bpmCfg.BundlePath(),

--- a/src/bpm/runc/lifecycle/lifecycle_test.go
+++ b/src/bpm/runc/lifecycle/lifecycle_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -147,37 +146,6 @@ var _ = Describe("RuncJobLifecycle", func() {
 			Expect(cid).To(Equal(expectedContainerID))
 			Expect(stdout).To(Equal(expectedStdout))
 			Expect(stderr).To(Equal(expectedStderr))
-		})
-
-		Context("when a PreStart Hook is provided", func() {
-			BeforeEach(func() {
-				procCfg.Hooks = &config.Hooks{
-					PreStart: "/please/execute/me",
-				}
-			})
-
-			It("executes the pre start hook", func() {
-				err := runcLifecycle.StartJob(bpmCfg, procCfg)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedCommand := exec.Command("/bin/bash", "-c", procCfg.Hooks.PreStart)
-				expectedCommand.Stdout = expectedStdout
-				expectedCommand.Stderr = expectedStderr
-
-				Expect(fakeCommandRunner.RunCallCount()).To(Equal(1))
-				Expect(fakeCommandRunner.RunArgsForCall(0)).To(Equal(expectedCommand))
-			})
-
-			Context("when the PreStart Hook fails", func() {
-				BeforeEach(func() {
-					fakeCommandRunner.RunReturns(errors.New("boom!"))
-				})
-
-				It("returns an error", func() {
-					err := runcLifecycle.StartJob(bpmCfg, procCfg)
-					Expect(err).To(HaveOccurred())
-				})
-			})
 		})
 
 		Context("when the process name is the same as the job name", func() {


### PR DESCRIPTION
Runc provides a lifecycle for executing Prestart, Poststart, and
Poststop. This change leverages those concepts to execute our pre_start
hook.