### PR TITLE
job-process working directory defaults to JobDir

### DIFF
--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -126,7 +126,7 @@ func (a *RuncAdapter) BuildSpec(
 	procCfg *config.ProcessConfig,
 	user specs.User,
 ) (specs.Spec, error) {
-	cwd := "/"
+	cwd := bpmCfg.JobDir()
 	if procCfg.WorkDir != "" {
 		cwd = procCfg.WorkDir
 	}

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -238,7 +238,7 @@ var _ = Describe("RuncAdapter", func() {
 			Expect(spec.Process.User).To(Equal(user))
 			Expect(spec.Process.Args).To(Equal(expectedProcessArgs))
 			Expect(spec.Process.Env).To(ConsistOf(expectedEnv))
-			Expect(spec.Process.Cwd).To(Equal("/"))
+			Expect(spec.Process.Cwd).To(Equal(bpmCfg.JobDir()))
 			Expect(spec.Process.Rlimits).To(Equal([]specs.POSIXRlimit{}))
 			Expect(spec.Process.NoNewPrivileges).To(Equal(true))
 			Expect(spec.Process.Capabilities).To(Equal(&specs.LinuxCapabilities{


### PR DESCRIPTION
If `bpm.yml` does not set `work_dir` then use the job's directory
`/var/vcap/jobs/<job>`

[finishes #152559919]