### PR TITLE
move logs from .{out,err}.log to .std{out,err}.log

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -34,8 +34,8 @@ your process while running the drain script.
 
 Your process should write logs to standard output and standard error file
 descriptors. This data will be written to
-`/var/vcap/sys/log/[job-name]/[process-name].out.log` and
-`/var/vcap/sys/log/[job-name]/[process-name].err.log` respectively.
+`/var/vcap/sys/log/[job-name]/[process-name].stdout.log` and
+`/var/vcap/sys/log/[job-name]/[process-name].stderr.log` respectively.
 
 Any other files which are written to `/var/vcap/sys/log/[job-name]` inside the
 container will be written to `/var/vcap/sys/log/[job-name]` in the host system.

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -82,11 +82,11 @@ func (c *BPMConfig) LogDir() string {
 }
 
 func (c *BPMConfig) Stdout() string {
-	return filepath.Join(c.LogDir(), fmt.Sprintf("%s.out.log", c.procName))
+	return filepath.Join(c.LogDir(), fmt.Sprintf("%s.stdout.log", c.procName))
 }
 
 func (c *BPMConfig) Stderr() string {
-	return filepath.Join(c.LogDir(), fmt.Sprintf("%s.err.log", c.procName))
+	return filepath.Join(c.LogDir(), fmt.Sprintf("%s.stderr.log", c.procName))
 }
 
 func (c *BPMConfig) PidDir() string {

--- a/src/bpm/integration/capabilities_test.go
+++ b/src/bpm/integration/capabilities_test.go
@@ -54,7 +54,7 @@ var _ = Describe("capabilities", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", job))
+		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", job))
 
 		cfg = newJobConfig(job, effectiveCapabiltiesBash)
 	})

--- a/src/bpm/integration/logs_test.go
+++ b/src/bpm/integration/logs_test.go
@@ -54,8 +54,8 @@ var _ = Describe("logs", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", job))
-		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", job))
+		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", job))
+		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", job))
 
 		cfg = newJobConfig(job, logsBash)
 
@@ -241,8 +241,8 @@ var _ = Describe("logs", func() {
 				},
 			})
 
-			otherStdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", process))
-			otherStderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", process))
+			otherStdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", process))
+			otherStderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", process))
 
 			command = exec.Command(bpmPath, "logs", job, "-p", process)
 		})

--- a/src/bpm/integration/namespaces_test.go
+++ b/src/bpm/integration/namespaces_test.go
@@ -54,7 +54,7 @@ var _ = Describe("start", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", job))
+		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", job))
 	})
 
 	JustBeforeEach(func() {

--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -55,7 +55,7 @@ var _ = Describe("resource limits", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", job))
+		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", job))
 	})
 
 	JustBeforeEach(func() {

--- a/src/bpm/integration/start_test.go
+++ b/src/bpm/integration/start_test.go
@@ -58,8 +58,8 @@ var _ = Describe("start", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", job))
-		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", job))
+		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", job))
+		stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", job))
 		bpmLog = filepath.Join(boshRoot, "sys", "log", job, "bpm.log")
 		logFile = filepath.Join(boshRoot, "sys", "log", job, "foo.log")
 		pidFile = filepath.Join(boshRoot, "sys", "run", "bpm", job, fmt.Sprintf("%s.pid", job))
@@ -153,8 +153,8 @@ var _ = Describe("start", func() {
 				},
 			})
 
-			stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", process))
-			stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.err.log", process))
+			stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", process))
+			stderr = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stderr.log", process))
 			pidFile = filepath.Join(boshRoot, "sys", "run", "bpm", job, fmt.Sprintf("%s.pid", process))
 		})
 

--- a/src/bpm/integration/stop_test.go
+++ b/src/bpm/integration/stop_test.go
@@ -55,7 +55,7 @@ var _ = Describe("stop", func() {
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
 		runcRoot = setupBoshDirectories(boshRoot, job)
 
-		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.out.log", job))
+		stdout = filepath.Join(boshRoot, "sys", "log", job, fmt.Sprintf("%s.stdout.log", job))
 		bpmLog = filepath.Join(boshRoot, "sys", "log", job, "bpm.log")
 		logFile = filepath.Join(boshRoot, "sys", "log", job, "foo.log")
 


### PR DESCRIPTION
This helps keep consistency with other BOSH logs (such as pre-start
logs) which use this convention. We do not believe anyone is depending
directly on the log file name. Any syslog forwarders and log rotators
should only be looking for the *.log suffix.

The commands used for this change were:

  grep -rl ".out.log" src/ docs/ | xargs sed -i 's/\.out\.log/.stdout.log/g'
  grep -rl ".err.log" src/ docs/ | xargs sed -i 's/\.err\.log/.stderr.log/g'