### PR TITLE
check docker permissions without groups

### DIFF
--- a/scripts/checkdocker.sh
+++ b/scripts/checkdocker.sh
@@ -1,0 +1,8 @@
+# The Docker CLI does not need to be run as root in order to be safe in all
+# cases. For example, when running on MacOS it is quarantined to a different
+# virtual machine. If you are running daemon on a local machine then practice
+# caution with sudo-less docker invocations.
+user_can_docker() {
+  docker info 2>&1 | grep -qv "permission denied"
+}
+

--- a/scripts/start-docker
+++ b/scripts/start-docker
@@ -3,14 +3,22 @@
 absolute_path() {
   (cd "$1" && pwd)
 }
-
 scripts_path=$(absolute_path "$(dirname "$0")" )
 
-sudo docker pull pcfsecurity/bpm-ci:latest
+. "$scripts_path/checkdocker.sh"
 
-sudo docker run \
+if user_can_docker; then
+  DOCKER="docker"
+else
+  # On development workstations docker must run as root.
+  # These settings are not related to the privileges that bpm creates runc containers with.
+  DOCKER="sudo docker"
+fi
+
+$DOCKER pull pcfsecurity/bpm-ci:latest
+$DOCKER run \
   --privileged \
-  -v  ${scripts_path}/..:/bpm \
+  -v  "${scripts_path}/..:/bpm" \
   -e "GOPATH=/bpm" \
   -it pcfsecurity/bpm-ci:latest \
   /bin/bash -c 'export PATH=$PATH:$GOPATH/bin; /bin/bash'

--- a/scripts/test-with-docker
+++ b/scripts/test-with-docker
@@ -5,26 +5,20 @@ set -e
 absolute_path() {
   (cd "$1" && pwd)
 }
-
-user_has_group() {
-  local user="$1"
-  local group="$2"
-
-  id -nG "${user}" | grep -qw "${group}"
-}
-
 scripts_path=$(absolute_path "$(dirname "$0")" )
 
-if user_has_group "$USER" "docker"; then
+. "$scripts_path/checkdocker.sh"
+
+if user_can_docker; then
   DOCKER="docker"
 else
+  # On development workstations docker must run as root.
+  # These settings are not related to the privileges that bpm creates runc containers with.
   DOCKER="sudo docker"
 fi
 
 $DOCKER pull pcfsecurity/bpm-ci:latest
 
-# On development workstations docker must run as root.
-# These settings are not related to the privileges that bpm creates runc containers with.
 $DOCKER run \
   --privileged \
   -v "${scripts_path}/..:/bpm" \


### PR DESCRIPTION
I originally wanted this fix because the privilege escalation is not
required on MacOS but ended up tunnel-visioning on the implementation
for the Linux workstation I was working on. This caused two issues:

  1) It encouraged users to add the docker group to their user which has
     a number of security caveats[1] as reported by @jfmyers9.

  2) The fix doesn't even work on MacOS.

This new implementation checks if a user can use sudo-less docker
commands by actually trying to run one rather than trying to infer it
from the environment. This addresses the two points above.

[1]: https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface