### PR TITLE
Support 'exec' mounts for additional volumes

### DIFF
--- a/src/bpm/config/fixtures/example.yml
+++ b/src/bpm/config/fixtures/example.yml
@@ -18,7 +18,7 @@ processes:
     writable: false
   - path: /var/vcap/data/jna-tmp
     writable: true
-    executions: true
+    allow_executions: true
   hooks:
     pre_start: /var/vcap/jobs/program/bin/pre
   capabilities:

--- a/src/bpm/config/fixtures/example.yml
+++ b/src/bpm/config/fixtures/example.yml
@@ -16,6 +16,9 @@ processes:
     writable: true
   - path: /var/vcap/data/alternate-program
     writable: false
+  - path: /var/vcap/data/jna-tmp
+    writable: true
+    executions: true
   hooks:
     pre_start: /var/vcap/jobs/program/bin/pre
   capabilities:

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -54,9 +54,9 @@ type Hooks struct {
 }
 
 type Volume struct {
-	Path       string `yaml:"path"`
-	Writable   bool   `yaml:"writable"`
-	Executions bool   `yaml:"executions"`
+	Path            string `yaml:"path"`
+	Writable        bool   `yaml:"writable"`
+	AllowExecutions bool   `yaml:"allow_executions"`
 }
 
 func ParseJobConfig(configPath string) (*JobConfig, error) {

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -54,8 +54,9 @@ type Hooks struct {
 }
 
 type Volume struct {
-	Path     string `yaml:"path"`
-	Writable bool   `yaml:"writable"`
+	Path       string `yaml:"path"`
+	Writable   bool   `yaml:"writable"`
+	Executions bool   `yaml:"executions"`
 }
 
 func ParseJobConfig(configPath string) (*JobConfig, error) {

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Processes[0].AdditionalVolumes).To(ConsistOf(
 				config.Volume{Path: "/var/vcap/data/program/foobar", Writable: true},
 				config.Volume{Path: "/var/vcap/data/alternate-program"},
-				config.Volume{Path: "/var/vcap/data/jna-tmp", Writable: true, Executions: true},
+				config.Volume{Path: "/var/vcap/data/jna-tmp", Writable: true, AllowExecutions: true},
 			))
 			Expect(cfg.Processes[0].Hooks.PreStart).To(Equal("/var/vcap/jobs/program/bin/pre"))
 			Expect(cfg.Processes[0].Capabilities).To(ConsistOf("NET_BIND_SERVICE"))

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Processes[0].AdditionalVolumes).To(ConsistOf(
 				config.Volume{Path: "/var/vcap/data/program/foobar", Writable: true},
 				config.Volume{Path: "/var/vcap/data/alternate-program"},
+				config.Volume{Path: "/var/vcap/data/jna-tmp", Writable: true, Executions: true},
 			))
 			Expect(cfg.Processes[0].Hooks.PreStart).To(Equal("/var/vcap/jobs/program/bin/pre"))
 			Expect(cfg.Processes[0].Capabilities).To(ConsistOf("NET_BIND_SERVICE"))

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -312,11 +312,15 @@ func userProvidedIdentityMounts(logger lager.Logger, bpmCfg *config.BPMConfig, v
 			logger.Info("duplicate-volume", lager.Data{"volume": vol.Path})
 			continue
 		}
-		if vol.Writable {
-			mnts = append(mnts, identityBindMountWithOptions(vol.Path, "nodev", "nosuid", "noexec", "rbind", "rw"))
-		} else {
-			mnts = append(mnts, identityBindMountWithOptions(vol.Path, "nodev", "nosuid", "noexec", "rbind", "ro"))
+		execOpt := "noexec"
+		if vol.Executions {
+			execOpt = "exec"
 		}
+		writeOpt := "ro"
+		if vol.Writable {
+			writeOpt = "rw"
+		}
+		mnts = append(mnts, identityBindMountWithOptions(vol.Path, "nodev", "nosuid", execOpt, "rbind", writeOpt))
 		mntsSeen[vol.Path] = true
 	}
 

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -313,7 +313,7 @@ func userProvidedIdentityMounts(logger lager.Logger, bpmCfg *config.BPMConfig, v
 			continue
 		}
 		execOpt := "noexec"
-		if vol.Executions {
+		if vol.AllowExecutions {
 			execOpt = "exec"
 		}
 		writeOpt := "ro"

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -198,7 +198,7 @@ var _ = Describe("RuncAdapter", func() {
 				},
 				AdditionalVolumes: []config.Volume{
 					{Path: "/path/to/volume/1", Writable: true},
-					{Path: "/path/to/volume/jna-tmp", Writable: true, Executions: true},
+					{Path: "/path/to/volume/jna-tmp", Writable: true, AllowExecutions: true},
 					// Testing duplicate volumes
 					{Path: "/path/to/volume/2"},
 					{Path: "/path/to/volume/2"},

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -198,6 +198,7 @@ var _ = Describe("RuncAdapter", func() {
 				},
 				AdditionalVolumes: []config.Volume{
 					{Path: "/path/to/volume/1", Writable: true},
+					{Path: "/path/to/volume/jna-tmp", Writable: true, Executions: true},
 					// Testing duplicate volumes
 					{Path: "/path/to/volume/2"},
 					{Path: "/path/to/volume/2"},
@@ -349,6 +350,12 @@ var _ = Describe("RuncAdapter", func() {
 					Type:        "bind",
 					Source:      "/path/to/volume/1",
 					Options:     []string{"nodev", "nosuid", "noexec", "rbind", "rw"},
+				},
+				{
+					Destination: "/path/to/volume/jna-tmp",
+					Type:        "bind",
+					Source:      "/path/to/volume/jna-tmp",
+					Options:     []string{"nodev", "nosuid", "exec", "rbind", "rw"},
 				},
 				{
 					Destination: "/path/to/volume/2",


### PR DESCRIPTION
Hi folks,

This is a patch adding support for `exec` mounts, as requested in issue #37.
Here we introduce a new `executions` boolean option to additional volumes.

Docker tests (as run with `./scripts/test-with-docker`) are passing. In config tests, I added the new boolean to the fixture for valid config. In RunC adapter tests, I added a test for when the `Executions` boolean is true.

Please let me know if you'd like any further work on this, and thank you for your review!

Cheers,
Benjamin