### PR TITLE
Remind user to enable swap accounting when the test fails

### DIFF
--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -104,6 +104,8 @@ var _ = Describe("resource limits", func() {
 		}
 
 		It("gets OOMed when it exceeds its memory limit", func() {
+			fmt.Fprintln(GinkgoWriter, "If this test fails then make sure you enable swap accounting! Details are in the README.")
+
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0))

--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -104,7 +104,7 @@ var _ = Describe("resource limits", func() {
 		}
 
 		It("gets OOMed when it exceeds its memory limit", func() {
-			fmt.Fprintln(GinkgoWriter, "If this test fails then make sure you enable swap accounting! Details are in the README.")
+			fmt.Fprintln(GinkgoWriter, "If this test fails, then make sure you have enabled swap accounting! Details are in the README.")
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This is a common source of failures when running the tests initially. I
often forget to enable this when setting up new machines.