### PR TITLE
 Include stopped processes in list command output

### DIFF
--- a/src/bpm/config/bosh.go
+++ b/src/bpm/config/bosh.go
@@ -40,19 +40,17 @@ func (b *Bosh) Root() string {
 	return b.root
 }
 
-func (b *Bosh) JobPaths() []string {
-	var jobDirs []string
+func (b *Bosh) JobNames() []string {
+	var jobs []string
 
-	dirInfos, err := ioutil.ReadDir(b.root)
+	fileInfos, err := ioutil.ReadDir(filepath.Join(b.root, "jobs"))
 	if err != nil {
-		return jobDirs
+		return jobs
 	}
 
-	for _, dirInfo := range dirInfos {
-		if dirInfo.IsDir() {
-			jobDirs = append(jobDirs, filepath.Join(b.root, dirInfo.Name()))
-		}
+	for _, info := range fileInfos {
+		jobs = append(jobs, info.Name())
 	}
 
-	return jobDirs
+	return jobs
 }

--- a/src/bpm/config/bosh_test.go
+++ b/src/bpm/config/bosh_test.go
@@ -54,22 +54,15 @@ var _ = Describe("Bosh", func() {
 		})
 	})
 
-	Describe("JobPaths", func() {
+	Describe("JobNames", func() {
 		BeforeEach(func() {
-			Expect(os.Mkdir(filepath.Join(root, "job-a"), 0700)).To(Succeed())
-			Expect(os.Mkdir(filepath.Join(root, "job-b"), 0700)).To(Succeed())
-
-			_, err := os.Create(filepath.Join(root, "not-a-directory"))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(os.MkdirAll(filepath.Join(root, "jobs", "job-a"), 0700)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(root, "jobs", "job-b"), 0700)).To(Succeed())
 		})
 
 		It("returns a list of BOSH job directories", func() {
-			paths := config.NewBosh(root).JobPaths()
-
-			Expect(paths).To(ConsistOf(
-				filepath.Join(root, "job-a"),
-				filepath.Join(root, "job-b"),
-			))
+			paths := config.NewBosh(root).JobNames()
+			Expect(paths).To(ConsistOf("job-a", "job-b"))
 		})
 	})
 })

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -103,12 +103,8 @@ func (c *BPMConfig) JobDir() string {
 	return filepath.Join(c.boshRoot, "jobs", c.jobName)
 }
 
-func (c *BPMConfig) ConfigDir() string {
-	return filepath.Join(c.JobDir(), "config")
-}
-
 func (c *BPMConfig) JobConfig() string {
-	return filepath.Join(c.ConfigDir(), "bpm.yml")
+	return filepath.Join(c.JobDir(), "config", "bpm.yml")
 }
 
 func (c *BPMConfig) BPMLog() string {
@@ -123,7 +119,7 @@ func (c *BPMConfig) RootFSPath() string {
 	return filepath.Join(c.BundlePath(), "rootfs")
 }
 
-func (c *BPMConfig) ContainerID(encoded bool) string {
+func (c *BPMConfig) ContainerID() string {
 	var containerID string
 
 	if c.jobName == c.procName {
@@ -132,15 +128,11 @@ func (c *BPMConfig) ContainerID(encoded bool) string {
 		containerID = fmt.Sprintf("%s.%s", c.jobName, c.procName)
 	}
 
-	if encoded {
-		containerID = Encode(containerID)
-	}
-
-	return containerID
+	// runc spec only allows `^[\w+-\.]+$`
+	// https://github.com/opencontainers/runc/blob/master/libcontainer/factory_linux.go
+	return Encode(containerID)
 }
 
-// runc spec only allows `^[\w+-\.]+$`
-// https://github.com/opencontainers/runc/blob/master/libcontainer/factory_linux.go
 func Encode(containerID string) string {
 	enc := base32.StdEncoding
 	enc = enc.WithPadding('-')

--- a/src/bpm/config/bpm_config_test.go
+++ b/src/bpm/config/bpm_config_test.go
@@ -49,14 +49,9 @@ var _ = Describe("Config", func() {
 					bpmCfg = config.NewBPMConfig("", "foo", "foo")
 				})
 
-				It("encodes when passed true", func() {
-					encoded := bpmCfg.ContainerID(true)
+				It("encodes", func() {
+					encoded := bpmCfg.ContainerID()
 					Expect(encoded).To(Equal("MZXW6---"))
-				})
-
-				It("doesn't encode when passed false", func() {
-					plain := bpmCfg.ContainerID(false)
-					Expect(plain).To(Equal("foo"))
 				})
 			})
 
@@ -65,14 +60,9 @@ var _ = Describe("Config", func() {
 					bpmCfg = config.NewBPMConfig("", "foo", "bar")
 				})
 
-				It("encodes when passed the true", func() {
-					encoded := bpmCfg.ContainerID(true)
+				It("encodes", func() {
+					encoded := bpmCfg.ContainerID()
 					Expect(encoded).To(Equal("MZXW6LTCMFZA----"))
-				})
-
-				It("doesn't encode when passed false", func() {
-					encoded := bpmCfg.ContainerID(false)
-					Expect(encoded).To(Equal("foo.bar"))
 				})
 			})
 		})

--- a/src/bpm/integration/integration_suite_test.go
+++ b/src/bpm/integration/integration_suite_test.go
@@ -139,6 +139,14 @@ func writeConfig(root, job string, cfg config.JobConfig) {
 	Expect(ioutil.WriteFile(configPath, data, 0644)).To(Succeed())
 }
 
+func writeInvalidConfig(root, job string) {
+	configDir := filepath.Join(root, "jobs", job, "config")
+	Expect(os.MkdirAll(configDir, 0755)).To(Succeed())
+
+	configPath := filepath.Join(configDir, "bpm.yml")
+	Expect(ioutil.WriteFile(configPath, []byte("{{"), 0644)).To(Succeed())
+}
+
 func startJob(root, bpmPath, j string) {
 	startCommand := exec.Command(bpmPath, "start", j)
 	startCommand.Env = append(startCommand.Env, fmt.Sprintf("BPM_BOSH_ROOT=%s", root))

--- a/src/bpm/models/models.go
+++ b/src/bpm/models/models.go
@@ -16,8 +16,9 @@
 package models
 
 const (
-	ProcessStateRunning = "running"
 	ProcessStateFailed  = "failed"
+	ProcessStateRunning = "running"
+	ProcessStateStopped = "stopped"
 )
 
 type Process struct {

--- a/src/bpm/runc/lifecycle/lifecycle.go
+++ b/src/bpm/runc/lifecycle/lifecycle.go
@@ -145,7 +145,7 @@ func (j *RuncLifecycle) StartProcess(logger lager.Logger, bpmCfg *config.BPMConf
 	return j.runcClient.RunContainer(
 		bpmCfg.PidFile(),
 		bpmCfg.BundlePath(),
-		bpmCfg.ContainerID(true),
+		bpmCfg.ContainerID(),
 		stdout,
 		stderr,
 	)
@@ -156,7 +156,7 @@ func (j *RuncLifecycle) StartProcess(logger lager.Logger, bpmCfg *config.BPMConf
 // - nil,nil if the process is not running and there is no other error
 // - nil,error if there is any other error getting the process beyond it not running
 func (j *RuncLifecycle) GetProcess(cfg *config.BPMConfig) (*models.Process, error) {
-	container, err := j.runcClient.ContainerState(cfg.ContainerID(true))
+	container, err := j.runcClient.ContainerState(cfg.ContainerID())
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (j *RuncLifecycle) GetProcess(cfg *config.BPMConfig) (*models.Process, erro
 }
 
 func (j *RuncLifecycle) OpenShell(cfg *config.BPMConfig, stdin io.Reader, stdout, stderr io.Writer) error {
-	return j.runcClient.Exec(cfg.ContainerID(true), "/bin/bash", stdin, stdout, stderr)
+	return j.runcClient.Exec(cfg.ContainerID(), "/bin/bash", stdin, stdout, stderr)
 }
 
 func (j *RuncLifecycle) ListProcesses() ([]*models.Process, error) {
@@ -195,12 +195,12 @@ func (j *RuncLifecycle) ListProcesses() ([]*models.Process, error) {
 }
 
 func (j *RuncLifecycle) StopProcess(logger lager.Logger, cfg *config.BPMConfig, exitTimeout time.Duration) error {
-	err := j.runcClient.SignalContainer(cfg.ContainerID(true), client.Term)
+	err := j.runcClient.SignalContainer(cfg.ContainerID(), client.Term)
 	if err != nil {
 		return err
 	}
 
-	state, err := j.runcClient.ContainerState(cfg.ContainerID(true))
+	state, err := j.runcClient.ContainerState(cfg.ContainerID())
 	if err != nil {
 		logger.Error("failed-to-fetch-state", err)
 	} else {
@@ -216,7 +216,7 @@ func (j *RuncLifecycle) StopProcess(logger lager.Logger, cfg *config.BPMConfig, 
 	for {
 		select {
 		case <-stateTicker.C():
-			state, err = j.runcClient.ContainerState(cfg.ContainerID(true))
+			state, err = j.runcClient.ContainerState(cfg.ContainerID())
 			if err != nil {
 				logger.Error("failed-to-fetch-state", err)
 			} else {
@@ -225,7 +225,7 @@ func (j *RuncLifecycle) StopProcess(logger lager.Logger, cfg *config.BPMConfig, 
 				}
 			}
 		case <-timeout.C():
-			err := j.runcClient.SignalContainer(cfg.ContainerID(true), client.Quit)
+			err := j.runcClient.SignalContainer(cfg.ContainerID(), client.Quit)
 			if err != nil {
 				logger.Error("failed-to-sigquit", err)
 			}
@@ -237,7 +237,7 @@ func (j *RuncLifecycle) StopProcess(logger lager.Logger, cfg *config.BPMConfig, 
 }
 
 func (j *RuncLifecycle) RemoveProcess(cfg *config.BPMConfig) error {
-	err := j.runcClient.DeleteContainer(cfg.ContainerID(true))
+	err := j.runcClient.DeleteContainer(cfg.ContainerID())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Finishes: https://www.pivotaltracker.com/story/show/152366823

Contrary to the story description, I chose not to exit with a non-zero exit code on warnings. I feel that `bpm list` technically succeeds in these cases and it would be incorrect to call it an error. Let me know if you think this behavior should be changed.