### PR TITLE
error if job uses reserved volume path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.0
 
 * do not limit swap space on hosts which do not support it
+* mounting reserved directories provides a more useful validation error
 
 # v0.6.0
 

--- a/src/bpm/commands/list.go
+++ b/src/bpm/commands/list.go
@@ -42,7 +42,7 @@ func listContainers(cmd *cobra.Command, _ []string) error {
 	processes := []*models.Process{}
 	for _, job := range bosh.JobNames() {
 		bpmCfg := config.NewBPMConfig(bosh.Root(), job, "")
-		jobCfg, err := config.ParseJobConfig(bpmCfg.JobConfig())
+		jobCfg, err := config.ParseJobConfig(bpmCfg.JobName(), bpmCfg.JobConfig())
 		if os.IsNotExist(err) {
 			continue
 		}

--- a/src/bpm/commands/start.go
+++ b/src/bpm/commands/start.go
@@ -60,7 +60,7 @@ func start(cmd *cobra.Command, _ []string) error {
 	logger.Info("starting")
 	defer logger.Info("complete")
 
-	jobCfg, err := config.ParseJobConfig(bpmCfg.JobConfig())
+	jobCfg, err := config.ParseJobConfig(bpmCfg.JobName(), bpmCfg.JobConfig())
 	if err != nil {
 		logger.Error("failed-to-parse-config", err)
 		return fmt.Errorf("failed to parse job configuration: %s", err)

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -202,16 +202,18 @@ var _ = Describe("RuncAdapter", func() {
 					"RAVE": "true",
 					"ONE":  "two",
 				},
+				EphemeralDisk:  true,
+				PersistentDisk: false,
 				AdditionalVolumes: []config.Volume{
 					{Path: "/path/to/volume/1", Writable: true},
 					{Path: "/path/to/volume/jna-tmp", Writable: true, AllowExecutions: true},
-					// Testing duplicate volumes
+					// Duplicate volumes
 					{Path: "/path/to/volume/2"},
 					{Path: "/path/to/volume/2"},
-					// Testing duplicate store mount and ignore writable flag
+					// Duplicate data mount
 					{Path: bpmCfg.DataDir()},
-					// Testing duplicate data mount
-					{Path: bpmCfg.StoreDir(), Writable: true},
+					// Testing store mount override
+					{Path: bpmCfg.StoreDir(), Writable: true, AllowExecutions: true},
 				},
 				Capabilities: []string{"TAIN", "SAICIN"},
 			}
@@ -260,7 +262,7 @@ var _ = Describe("RuncAdapter", func() {
 				Path: bpmCfg.RootFSPath(),
 			}))
 
-			Expect(spec.Mounts).To(HaveLen(22))
+			Expect(spec.Mounts).To(HaveLen(24))
 			Expect(spec.Mounts).To(ContainElement(specs.Mount{
 				Destination: "/proc",
 				Type:        "proc",
@@ -392,6 +394,18 @@ var _ = Describe("RuncAdapter", func() {
 				Type:        "bind",
 				Source:      filepath.Join(systemRoot, "data", "example", "tmp"),
 				Options:     []string{"nodev", "nosuid", "noexec", "rbind", "rw"},
+			}))
+			Expect(spec.Mounts).To(ContainElement(specs.Mount{
+				Destination: filepath.Join(systemRoot, "data", "example"),
+				Type:        "bind",
+				Source:      filepath.Join(systemRoot, "data", "example"),
+				Options:     []string{"nodev", "nosuid", "noexec", "rbind", "rw"},
+			}))
+			Expect(spec.Mounts).To(ContainElement(specs.Mount{
+				Destination: filepath.Join(systemRoot, "store", "example"),
+				Type:        "bind",
+				Source:      filepath.Join(systemRoot, "store", "example"),
+				Options:     []string{"nodev", "nosuid", "exec", "rbind", "rw"},
 			}))
 
 			Expect(spec.Linux.RootfsPropagation).To(Equal("private"))


### PR DESCRIPTION
We only write this to the log since this will normally be run by monit
and standard out and error will not be visible to the user.