### PR TITLE
🕰  `SYS_TIME` — capable of setting system clock

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,7 +17,7 @@ check process server
   stop program "/var/vcap/jobs/bpm/bin/bpm stop server"
   group vcap
 
-check process worker 
+check process worker
   with pidfile /var/vcap/sys/run/bpm/server/worker.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start server -p worker"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop server -p worker"
@@ -37,20 +37,20 @@ directory of your job.
 
 #### `process` Schema
 
-| **Property**         | **Type**         | **Required?** | **Description**                                                                                                                |
-|----------------------|------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `name`               | string           | Yes           | The name of this process.                                                                                                      |
-| `executable`         | string           | Yes           | The path to the executable file for this process.                                                                              |
-| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                                                        |
-| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.                                        |
-| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.                               |
-| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                                                           |
-| `capabilities`       | string[]         | No            | The list of capabilities which should be granted to this process. Currently only the `NET_BIND_SERVICE` capability is allowed. |
-| `limits`             | limits           | No            | The limit configuration for this process (see below).                                                                          |
-| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.                                 |
-| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.                               |
-| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below).                                                         |
-| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                                                         |
+| **Property**         | **Type**         | **Required?** | **Description**                                                                                   |
+| -------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------- |
+| `name`               | string           | Yes           | The name of this process.                                                                         |
+| `executable`         | string           | Yes           | The path to the executable file for this process.                                                 |
+| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                           |
+| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.           |
+| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.  |
+| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                              |
+| `capabilities`       | string[]         | No            | The list of [capabilities](#capabilities) which should be granted to this process.                |
+| `limits`             | limits           | No            | The limit configuration for this process (see below).                                             |
+| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.    |
+| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.  |
+| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below).                            |
+| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                            |
 
 #### `hooks` Schema
 
@@ -79,6 +79,13 @@ directory of your job.
 | **Property** | **Type** | **Required** | **Description**                                                                           |
 |--------------|----------|--------------|-------------------------------------------------------------------------------------------|
 | `privileged` | boolean  | No           | Whether or not this process should execute with increased privileges (see details below). |
+
+#### <a id="capabilities">Capabilities</a>
+
+| **Capability**     | **Description**                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `NET_BIND_SERVICE` | Bind a socket to Internet domain privileged ports (port numbers less than 1024).           |
+| `SYS_TIME`         | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
 
 ### Example
 

--- a/src/bpm/config/fixtures/example.yml
+++ b/src/bpm/config/fixtures/example.yml
@@ -23,6 +23,7 @@ processes:
     pre_start: /var/vcap/jobs/program/bin/pre
   capabilities:
   - NET_BIND_SERVICE
+  - SYS_TIME
   workdir: /I/AM/A/WORKDIR
   persistent_disk: true
   ephemeral_disk: true

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -92,6 +92,7 @@ const (
 
 var validCaps = map[string]bool{
 	"NET_BIND_SERVICE": true,
+	"SYS_TIME": true,
 }
 
 func (c *JobConfig) Validate() error {

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Config", func() {
 				config.Volume{Path: "/var/vcap/data/jna-tmp", Writable: true, AllowExecutions: true},
 			))
 			Expect(cfg.Processes[0].Hooks.PreStart).To(Equal("/var/vcap/jobs/program/bin/pre"))
-			Expect(cfg.Processes[0].Capabilities).To(ConsistOf("NET_BIND_SERVICE"))
+			Expect(cfg.Processes[0].Capabilities).To(ConsistOf("NET_BIND_SERVICE", "SYS_TIME"))
 			Expect(cfg.Processes[0].WorkDir).To(Equal("/I/AM/A/WORKDIR"))
 			Expect(cfg.Processes[0].PersistentDisk).To(BeTrue())
 			Expect(cfg.Processes[0].EphemeralDisk).To(BeTrue())


### PR DESCRIPTION
We'd like to be able to allow processes to set the system clock. This is targeted specifically towards the [BOSH NTP release](https://github.com/cloudfoundry-community/ntp-release). The NTP release contains `ntpd` (the Network Time Protocol daemon), an operating system program that maintains the system time in synchronization with time servers using the Network Time Protocol (NTP).