### PR TITLE
Add ParseJobConfig to the BPMConfig

### DIFF
--- a/src/bpm/commands/list.go
+++ b/src/bpm/commands/list.go
@@ -42,7 +42,7 @@ func listContainers(cmd *cobra.Command, _ []string) error {
 	processes := []*models.Process{}
 	for _, job := range bosh.JobNames() {
 		bpmCfg := config.NewBPMConfig(bosh.Root(), job, "")
-		jobCfg, err := config.ParseJobConfig(bpmCfg.JobName(), bpmCfg.JobConfig())
+		jobCfg, err := bpmCfg.ParseJobConfig()
 		if os.IsNotExist(err) {
 			continue
 		}

--- a/src/bpm/commands/start.go
+++ b/src/bpm/commands/start.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"bpm/config"
 	"bpm/models"
 	"bpm/runc/lifecycle"
 )
@@ -60,7 +59,7 @@ func start(cmd *cobra.Command, _ []string) error {
 	logger.Info("starting")
 	defer logger.Info("complete")
 
-	jobCfg, err := config.ParseJobConfig(bpmCfg.JobName(), bpmCfg.JobConfig())
+	jobCfg, err := bpmCfg.ParseJobConfig()
 	if err != nil {
 		logger.Error("failed-to-parse-config", err)
 		return fmt.Errorf("failed to parse job configuration: %s", err)

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -107,6 +107,22 @@ func (c *BPMConfig) JobConfig() string {
 	return filepath.Join(c.JobDir(), "config", "bpm.yml")
 }
 
+func (c *BPMConfig) ParseJobConfig() (*JobConfig, error) {
+	cfg, err := ParseJobConfig(c.JobConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	defaultVolumes := []string{c.DataDir(), c.StoreDir()}
+
+	err = cfg.Validate(defaultVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
 func (c *BPMConfig) BPMLog() string {
 	return filepath.Join(c.LogDir(), "bpm.log")
 }

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Config", func() {
 		})
 
 		It("parses a yaml file into a bpm config", func() {
-			cfg, err := config.ParseJobConfig(jobName, configPath)
+			cfg, err := config.ParseJobConfig(configPath)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedMemoryLimit := "100G"
@@ -81,7 +81,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := config.ParseJobConfig(jobName, configPath)
+				_, err := config.ParseJobConfig(configPath)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -92,18 +92,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := config.ParseJobConfig(jobName, configPath)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("when the configuration is not valid", func() {
-			BeforeEach(func() {
-				configPath = "fixtures/example-invalid-config.yml"
-			})
-
-			It("returns an error", func() {
-				_, err := config.ParseJobConfig(jobName, configPath)
+				_, err := config.ParseJobConfig(configPath)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -125,7 +114,7 @@ var _ = Describe("Config", func() {
 		})
 
 		It("does not error on a valid config", func() {
-			Expect(jobCfg.Validate(jobName)).To(Succeed())
+			Expect(jobCfg.Validate([]string{})).To(Succeed())
 		})
 
 		Context("when the config has additional_volumes that are not nested in `/var/vcap`", func() {
@@ -134,43 +123,40 @@ var _ = Describe("Config", func() {
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/bin"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/var/vcap/invalid"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/var/vcap/data"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/store"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "//var/vcap/data/valid"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 			})
 		})
 
-		Context("when the config has additional_volumes that conflict with the default store and data directories", func() {
+		Context("when the config has additional_volumes that conflict with default volumes", func() {
 			It("returns a validation error", func() {
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/job-name"},
 				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
-
-				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
-					{Path: "/var/vcap/store/job-name"},
-				}
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{
+					"/var/vcap/data/job-name",
+				})).To(HaveOccurred())
 			})
 		})
 
@@ -180,14 +166,14 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 			})
 		})
 
 		Context("when the process does not have a name", func() {
 			It("returns an error", func() {
 				jobCfg.Processes[0].Name = ""
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 			})
 		})
 
@@ -197,7 +183,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(jobCfg.Validate(jobName)).To(HaveOccurred())
+				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
This change adds a convenience method to the BPMConfig which parses the default location of the JobConfig and performs validation. This allows us to simplify the calling interface in the command layer and allows us to embed BPM specific validation logic in the BPMConfig object.

@xoebus This is what I had in mind for the config object. I like how it leaves the `JobConfig` agnostic of `JobName`, and the `bpmCfg.StoreDir()`/`bpmCfg.DataDir()`. Is there any reason why this may be undesirable?