### PR TITLE
Add support for unrestricted volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.8.0
+
+* add support for unrestricted volumes in unsafe configuration
+
 # v0.7.0
 
 * do not limit swap space on hosts which do not support it

--- a/docs/config.md
+++ b/docs/config.md
@@ -37,20 +37,20 @@ directory of your job.
 
 #### `process` Schema
 
-| **Property**         | **Type**         | **Required?** | **Description**                                                                                   |
-| -------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------- |
-| `name`               | string           | Yes           | The name of this process.                                                                         |
-| `executable`         | string           | Yes           | The path to the executable file for this process.                                                 |
-| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                           |
-| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.           |
-| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.  |
-| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                              |
-| `capabilities`       | string[]         | No            | The list of [capabilities][capabilities] (without CAP_) which should be granted to this process.  |
-| `limits`             | limits           | No            | The limit configuration for this process (see below).                                             |
-| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.    |
-| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.  |
-| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below).                            |
-| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                            |
+| **Property**         | **Type**         | **Required?** | **Description**                                                                                                                   |
+| -------------------- | ---------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | string           | Yes           | The name of this process.                                                                                                         |
+| `executable`         | string           | Yes           | The path to the executable file for this process.                                                                                 |
+| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                                                           |
+| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.                                           |
+| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.                                  |
+| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                                                              |
+| `capabilities`       | string[]         | No            | The list of [capabilities][capabilities] (without CAP_) which should be granted to this process.                                  |
+| `limits`             | limits           | No            | The limit configuration for this process (see below).                                                                             |
+| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.                                    |
+| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.                                  |
+| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below). They must be inside `/var/vcap/data` or `/var/vcap/store`. |
+| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                                                            |
 
 [capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
 
@@ -68,19 +68,21 @@ directory of your job.
 | `open_files` | int      | No           | The number of files this process is allowed to have open at any one time.                                                   |
 | `processes`  | int      | No           | The number of processes which this process is allowed to have running at any one moment (inclusive of the main process).    |
 
+#### `unsafe` Schema
+
+| **Property**           | **Type**  | **Required** | **Description**                                                                           |
+|--------------          |---------- |--------------|-------------------------------------------------------------------------------------------|
+| `privileged`           | boolean   | No           | Whether or not this process should execute with increased privileges (see details below). |
+| `unrestricted_volumes` | volume[]  | No           | An unrestricted list of additional volumes to mount inside this process (see below).      |
+
 #### `volume` Schema
 
 | **Property**       | **Type** | **Required** | **Description**                                                                                      |
 |--------------------|----------|--------------|------------------------------------------------------------------------------------------------------|
-| `path`             | string   | Yes          | The path of the volume inside this process. It must be inside `/var/vcap/data` or `/var/vcap/store`. |
+| `path`             | string   | Yes          | The path of the volume inside this process.                                                          |
 | `writable`         | boolean  | No           | Whether or not this volume is writable by the process.                                               |
 | `allow_executions` | boolean  | No           | Whether or not executable files can be executed from this volume.                                    |
 
-#### `unsafe` Schema
-
-| **Property** | **Type** | **Required** | **Description**                                                                           |
-|--------------|----------|--------------|-------------------------------------------------------------------------------------------|
-| `privileged` | boolean  | No           | Whether or not this process should execute with increased privileges (see details below). |
 
 ### Example
 

--- a/src/bpm/config/fixtures/example.yml
+++ b/src/bpm/config/fixtures/example.yml
@@ -29,6 +29,14 @@ processes:
   ephemeral_disk: true
   unsafe:
     privileged: true
+    unrestricted_volumes:
+    - path: /
+      writable: true
+    - path: /etc
+      writable: false
+    - path: /foobar
+      writable: true
+      allow_executions: true
 - name: second-process
   executable: /I/AM/A/SECOND-EXECUTABLE
 - name: third-process

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -61,7 +61,8 @@ type Volume struct {
 }
 
 type Unsafe struct {
-	Privileged bool `yaml:"privileged"`
+	Privileged          bool     `yaml:"privileged"`
+	UnrestrictedVolumes []Volume `yaml:"unrestricted_volumes"`
 }
 
 func ParseJobConfig(configPath string) (*JobConfig, error) {

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -57,6 +57,11 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Processes[0].PersistentDisk).To(BeTrue())
 			Expect(cfg.Processes[0].EphemeralDisk).To(BeTrue())
 			Expect(cfg.Processes[0].Unsafe.Privileged).To(BeTrue())
+			Expect(cfg.Processes[0].Unsafe.UnrestrictedVolumes).To(ConsistOf(
+				config.Volume{Path: "/", Writable: true},
+				config.Volume{Path: "/etc"},
+				config.Volume{Path: "/foobar", Writable: true, AllowExecutions: true},
+			))
 
 			Expect(cfg.Processes[1].Name).To(Equal("second-process"))
 			Expect(cfg.Processes[1].Executable).To(Equal("/I/AM/A/SECOND-EXECUTABLE"))

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -146,6 +146,9 @@ func (a *RuncAdapter) BuildSpec(
 	ms.addMounts(systemIdentityMounts(mountResolvConf))
 	ms.addMounts(boshMounts(bpmCfg, procCfg.EphemeralDisk, procCfg.PersistentDisk))
 	ms.addMounts(userProvidedIdentityMounts(bpmCfg, procCfg.AdditionalVolumes))
+	if procCfg.Unsafe != nil && len(procCfg.Unsafe.UnrestrictedVolumes) > 0 {
+		ms.addMounts(userProvidedIdentityMounts(bpmCfg, procCfg.Unsafe.UnrestrictedVolumes))
+	}
 
 	spec := specbuilder.Build(
 		specbuilder.WithRootFilesystem(bpmCfg.RootFSPath()),
@@ -284,7 +287,7 @@ func (d *dedupMounts) addMounts(ms []specs.Mount) {
 }
 
 func (d *dedupMounts) mounts() []specs.Mount {
-	var ms []specs.Mount
+	ms := make([]specs.Mount, 0, len(d.set))
 	for _, mount := range d.set {
 		ms = append(ms, mount)
 	}

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -702,5 +702,35 @@ var _ = Describe("RuncAdapter", func() {
 				}
 			})
 		})
+
+		Context("when the user requests unrestricted volumes", func() {
+			BeforeEach(func() {
+				procCfg.Unsafe = &config.Unsafe{
+					UnrestrictedVolumes: []config.Volume{
+						{Path: "/this/is/an/unrestricted/path"},
+						{Path: "/writable/executable/path", Writable: true, AllowExecutions: true},
+					},
+				}
+			})
+
+			It("adds the volumes to the list of mounts", func() {
+				spec, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(spec.Mounts).To(HaveLen(26))
+				Expect(spec.Mounts).To(ContainElement(specs.Mount{
+					Destination: "/this/is/an/unrestricted/path",
+					Type:        "bind",
+					Source:      "/this/is/an/unrestricted/path",
+					Options:     []string{"nodev", "nosuid", "noexec", "rbind", "ro"},
+				}))
+				Expect(spec.Mounts).To(ContainElement(specs.Mount{
+					Destination: "/writable/executable/path",
+					Type:        "bind",
+					Source:      "/writable/executable/path",
+					Options:     []string{"nodev", "nosuid", "exec", "rbind", "rw"},
+				}))
+			})
+		})
 	})
 })


### PR DESCRIPTION
This change allows users to specify a list of volumes in the unsafe
configuration block. Volumes within this list are not subject to the
restriction that they must be within `/var/vcap/data` or
`/var/vcap/store`.

This change enables jobs with complex filesystem dependencies to be
converted to use bpm.

[#158122381]