### PR TITLE
remove restriction on allowed capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * do not limit swap space on hosts which do not support it
 * mounting reserved directories provides a more useful validation error
-* allow granting the SYS_TIME capability
+* remove the restriction on allowed capabilities
 
 # v0.6.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,12 +45,14 @@ directory of your job.
 | `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.           |
 | `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.  |
 | `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                              |
-| `capabilities`       | string[]         | No            | The list of [capabilities](#capabilities) which should be granted to this process.                |
+| `capabilities`       | string[]         | No            | The list of [capabilities][capabilities] (without CAP_) which should be granted to this process.  |
 | `limits`             | limits           | No            | The limit configuration for this process (see below).                                             |
 | `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.    |
 | `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.  |
 | `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below).                            |
 | `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                            |
+
+[capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
 
 #### `hooks` Schema
 
@@ -79,13 +81,6 @@ directory of your job.
 | **Property** | **Type** | **Required** | **Description**                                                                           |
 |--------------|----------|--------------|-------------------------------------------------------------------------------------------|
 | `privileged` | boolean  | No           | Whether or not this process should execute with increased privileges (see details below). |
-
-#### <a id="capabilities">Capabilities</a>
-
-| **Capability**     | **Description**                                                                            |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| `NET_BIND_SERVICE` | Bind a socket to Internet domain privileged ports (port numbers less than 1024).           |
-| `SYS_TIME`         | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
 
 ### Example
 

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type JobConfig struct {
@@ -85,11 +85,6 @@ const (
 	validStoreVolumePrefix = "/var/vcap/store"
 )
 
-var validCaps = map[string]bool{
-	"NET_BIND_SERVICE": true,
-	"SYS_TIME":         true,
-}
-
 func (c *JobConfig) Validate(defaultVolumes []string) error {
 	for _, v := range c.Processes {
 		if err := v.Validate(defaultVolumes); err != nil {
@@ -128,15 +123,6 @@ func (c *ProcessConfig) Validate(defaultVolumes []string) error {
 				vol.Path,
 				validDataVolumePrefix,
 				validStoreVolumePrefix,
-			)
-		}
-	}
-
-	for _, capabilities := range c.Capabilities {
-		if _, ok := validCaps[capabilities]; !ok {
-			return fmt.Errorf(
-				"invalid capability: %s",
-				capabilities,
 			)
 		}
 	}

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -154,16 +154,6 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		Context("when the capabilities are not permitted", func() {
-			BeforeEach(func() {
-				jobCfg.Processes[0].Capabilities = []string{"YO_DOG_CAP"}
-			})
-
-			It("returns an error", func() {
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
-			})
-		})
-
 		Context("when the process does not have a name", func() {
 			It("returns an error", func() {
 				jobCfg.Processes[0].Name = ""


### PR DESCRIPTION
We don't want people reaching for the privileged option when they don't
need to be. We could provide a validation for the capabilities to help
protect against typos. I don't know if we want the maintenance burden
yet to keep up with newly added capabilities. The error from RunC is
good and descriptive for now:

  starting container process caused "unknown capability \"CAP_NOT_REAL\""