### PR TITLE
Sort mounts by length of destination in container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.7.1
+
+* sort mounts by ascending length of elements in destination path
+
 # v0.7.0
 
 * do not limit swap space on hosts which do not support it

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"code.cloudfoundry.org/bytefmt"
 	"code.cloudfoundry.org/lager"
@@ -237,10 +239,12 @@ func userProvidedIdentityMounts(bpmCfg *config.BPMConfig, volumes []config.Volum
 		if vol.AllowExecutions {
 			execOpt = "exec"
 		}
+
 		writeOpt := "ro"
 		if vol.Writable {
 			writeOpt = "rw"
 		}
+
 		mnts = append(mnts, identityBindMountWithOptions(vol.Path, "nodev", "nosuid", execOpt, "rbind", writeOpt))
 	}
 
@@ -285,9 +289,17 @@ func (d *dedupMounts) addMounts(ms []specs.Mount) {
 
 func (d *dedupMounts) mounts() []specs.Mount {
 	var ms []specs.Mount
+
 	for _, mount := range d.set {
 		ms = append(ms, mount)
 	}
+
+	sort.Slice(ms, func(i, j int) bool {
+		iElems := strings.Split(ms[i].Destination, "/")
+		jElems := strings.Split(ms[j].Destination, "/")
+		return len(iElems) < len(jElems)
+	})
+
 	return ms
 }
 


### PR DESCRIPTION
This change will give us more reliable behavior with regards to bind
mounts inside containers.

[#158398322]