### PR TITLE
lifecycle: decrease stop timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.0
+
+* decrease the time between SIGTERM and SIGKILL to 15 seconds from 20 seconds
+
 # v0.8.0
 
 * add the `bpm run` command for executing processes as short-lived commands

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -18,7 +18,7 @@ terminated.
 
 If you require longer than this then you should use a [drain script][drain] for
 your server. The drain script should put your server in such a state that it
-can shutdown within 20 seconds. It is acceptable and supported to terminate
+can shutdown within 15 seconds. It is acceptable and supported to terminate
 your process while running the drain script.
 
 [post-start]:https://bosh.io/docs/post-start.html 

--- a/src/bpm/commands/stop.go
+++ b/src/bpm/commands/stop.go
@@ -24,7 +24,7 @@ import (
 	"bpm/runc/lifecycle"
 )
 
-const DefaultStopTimeout = 20 * time.Second
+const DefaultStopTimeout = 15 * time.Second
 
 func init() {
 	stopCommand.Flags().StringVarP(&procName, "process", "p", "", "optional process name")

--- a/src/bpm/runc/lifecycle/lifecycle.go
+++ b/src/bpm/runc/lifecycle/lifecycle.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	ContainerSigQuitGracePeriod = 5 * time.Second
+	ContainerSigQuitGracePeriod = 2 * time.Second
 	ContainerStatePollInterval  = 1 * time.Second
 
 	ContainerStateRunning = "running"


### PR DESCRIPTION
We've seen these timeouts being reached when a job which ignores signals
is asked to stop on a heavily loaded machine. It can sometimes take over
5 seconds for a process to dissapear from the process table even when
being sent SIGKILL.

There isn't much we can do if the machine is so heavily loaded it can't
kill processes. We have a hard 30 second limit enforced by monit which
we want to adhere to.

[finishes #158202290]