### PR TITLE
adapter: allow skipping volume mkdir/chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.0
 
 * decrease the time between SIGTERM and SIGKILL to 15 seconds from 20 seconds
+* add the `mount_only` option for volumes
 
 # v0.8.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -77,11 +77,12 @@ directory of your job.
 
 #### `volume` Schema
 
-| **Property**       | **Type** | **Required** | **Description**                                                                                      |
-|--------------------|----------|--------------|------------------------------------------------------------------------------------------------------|
-| `path`             | string   | Yes          | The path of the volume inside this process.                                                          |
-| `writable`         | boolean  | No           | Whether or not this volume is writable by the process.                                               |
-| `allow_executions` | boolean  | No           | Whether or not executable files can be executed from this volume.                                    |
+| **Property**       | **Type** | **Required** | **Description**                                                                                                |
+|--------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------|
+| `path`             | string   | Yes          | The path of the volume inside this process.                                                                    |
+| `writable`         | boolean  | No           | Whether or not this volume is writable by the process.                                                         |
+| `allow_executions` | boolean  | No           | Whether or not executable files can be executed from this volume.                                              |
+| `mount_only`       | boolean  | No           | Whether or not BPM should just mount this directory rather than creating and chowning a backing directory too. |
 
 
 ### Example

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -58,6 +58,7 @@ type Volume struct {
 	Path            string `yaml:"path"`
 	Writable        bool   `yaml:"writable"`
 	AllowExecutions bool   `yaml:"allow_executions"`
+	MountOnly       bool   `yaml:"mount_only"`
 }
 
 type Unsafe struct {

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -57,19 +57,22 @@ func (a *RuncAdapter) CreateJobPrerequisites(
 		return nil, nil, err
 	}
 
-	var directories []string
+	var dirsToCreate []string
 	for _, vol := range procCfg.AdditionalVolumes {
-		directories = append(directories, vol.Path)
+		if vol.MountOnly {
+			continue
+		}
+		dirsToCreate = append(dirsToCreate, vol.Path)
 	}
 
-	directories = append(
-		directories,
+	dirsToCreate = append(
+		dirsToCreate,
 		bpmCfg.LogDir(),
 		bpmCfg.TempDir(),
 	)
 
 	if procCfg.EphemeralDisk {
-		directories = append(directories, bpmCfg.DataDir())
+		dirsToCreate = append(dirsToCreate, bpmCfg.DataDir())
 	}
 
 	if procCfg.PersistentDisk {
@@ -82,10 +85,10 @@ func (a *RuncAdapter) CreateJobPrerequisites(
 			return nil, nil, errors.New("requested persistent disk does not exist")
 		}
 
-		directories = append(directories, bpmCfg.StoreDir())
+		dirsToCreate = append(dirsToCreate, bpmCfg.StoreDir())
 	}
 
-	for _, dir := range directories {
+	for _, dir := range dirsToCreate {
 		err = createDirFor(dir, int(user.UID), int(user.GID))
 		if err != nil {
 			return nil, nil, err

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -144,6 +144,26 @@ var _ = Describe("RuncAdapter", func() {
 			}
 		})
 
+		Context("when a volume should be mounted only", func() {
+			BeforeEach(func() {
+				procCfg.AdditionalVolumes = append(procCfg.AdditionalVolumes, config.Volume{
+					Path:      filepath.Join(systemRoot, "mount", "only"),
+					MountOnly: true,
+				})
+			})
+
+			It("does not create that directory", func() {
+				_, _, err := runcAdapter.CreateJobPrerequisites(bpmCfg, procCfg, user)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, vol := range procCfg.AdditionalVolumes {
+					if vol.MountOnly {
+						Expect(vol.Path).NotTo(BeADirectory())
+					}
+				}
+			})
+		})
+
 		Context("when the user requests a persistent disk", func() {
 			BeforeEach(func() {
 				procCfg.PersistentDisk = true


### PR DESCRIPTION
Some volumes (such as NFS mounts) return an error when they are chowned
even if the user is root. By setting this new option we assume that the
directory is already in a good state and we can just mount it into the
job.

[fixes #158544043]