### PR TITLE
Allow regular files to be specified in additional volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.10.0
 
-* mount cgroup subsystems at canonical location 
+* allow users to specify regular files in `additional_volumes`
+* mount cgroup subsystems at canonical location
 
 # v0.9.0
 

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -115,7 +115,7 @@ func (c *BPMConfig) ParseJobConfig() (*JobConfig, error) {
 
 	defaultVolumes := []string{c.DataDir(), c.StoreDir()}
 
-	err = cfg.Validate(defaultVolumes)
+	err = cfg.Validate(c.boshRoot, defaultVolumes)
 	if err != nil {
 		return nil, err
 	}

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -82,14 +82,9 @@ func ParseJobConfig(configPath string) (*JobConfig, error) {
 	return &cfg, nil
 }
 
-const (
-	validDataVolumePrefix  = "/var/vcap/data"
-	validStoreVolumePrefix = "/var/vcap/store"
-)
-
-func (c *JobConfig) Validate(defaultVolumes []string) error {
+func (c *JobConfig) Validate(boshRoot string, defaultVolumes []string) error {
 	for _, v := range c.Processes {
-		if err := v.Validate(defaultVolumes); err != nil {
+		if err := v.Validate(boshRoot, defaultVolumes); err != nil {
 			return err
 		}
 	}
@@ -97,7 +92,7 @@ func (c *JobConfig) Validate(defaultVolumes []string) error {
 	return nil
 }
 
-func (c *ProcessConfig) Validate(defaultVolumes []string) error {
+func (c *ProcessConfig) Validate(boshRoot string, defaultVolumes []string) error {
 	if c.Name == "" {
 		return errors.New("invalid config: name")
 	}
@@ -105,6 +100,9 @@ func (c *ProcessConfig) Validate(defaultVolumes []string) error {
 	if c.Executable == "" {
 		return errors.New("invalid config: executable")
 	}
+
+	validDataVolumePrefix := filepath.Join(boshRoot, "data")
+	validStoreVolumePrefix := filepath.Join(boshRoot, "store")
 
 	for _, vol := range c.AdditionalVolumes {
 		volCleaned := filepath.Clean(vol.Path)

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -104,47 +104,50 @@ var _ = Describe("Config", func() {
 			jobCfg = &config.JobConfig{
 				Processes: []*config.ProcessConfig{
 					{
-						Name:              "example",
-						Executable:        "executable",
-						AdditionalVolumes: []config.Volume{},
+						Name:       "example",
+						Executable: "executable",
+						AdditionalVolumes: []config.Volume{
+							{Path: "/var/vcap/data/valid"},
+							{Path: "/var/vcap/store/valid"},
+						},
 					},
 				},
 			}
 		})
 
 		It("does not error on a valid config", func() {
-			Expect(jobCfg.Validate([]string{})).To(Succeed())
+			Expect(jobCfg.Validate("/var/vcap", []string{})).To(Succeed())
 		})
 
-		Context("when the config has additional_volumes that are not nested in `/var/vcap`", func() {
+		Context("when the config has additional_volumes that are not nested in the bosh root", func() {
 			It("returns a validation error", func() {
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/bin"},
 				}
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("/var/vcap", []string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/var/vcap/invalid"},
 				}
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("/var/vcap", []string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/valid"},
 					{Path: "/var/vcap/data"},
 				}
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("/var/vcap", []string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/store"},
 				}
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("/var/vcap", []string{})).To(HaveOccurred())
 
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "//var/vcap/data/valid"},
 				}
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("/var/vcap", []string{})).To(HaveOccurred())
 			})
 		})
 
@@ -153,7 +156,7 @@ var _ = Describe("Config", func() {
 				jobCfg.Processes[0].AdditionalVolumes = []config.Volume{
 					{Path: "/var/vcap/data/job-name"},
 				}
-				Expect(jobCfg.Validate([]string{
+				Expect(jobCfg.Validate("/var/vcap", []string{
 					"/var/vcap/data/job-name",
 				})).To(HaveOccurred())
 			})
@@ -162,7 +165,7 @@ var _ = Describe("Config", func() {
 		Context("when the process does not have a name", func() {
 			It("returns an error", func() {
 				jobCfg.Processes[0].Name = ""
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("", []string{})).To(HaveOccurred())
 			})
 		})
 
@@ -172,7 +175,7 @@ var _ = Describe("Config", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(jobCfg.Validate([]string{})).To(HaveOccurred())
+				Expect(jobCfg.Validate("", []string{})).To(HaveOccurred())
 			})
 		})
 	})

--- a/src/bpm/integration/bash_test.go
+++ b/src/bpm/integration/bash_test.go
@@ -108,3 +108,11 @@ fi
 sleep 100 &
 child=$!;
 wait $child`
+
+func catBash(path string) string {
+	return fmt.Sprintf(`trap "echo 'Received a Signal' && kill -9 $child" SIGTERM;
+cat %s;
+sleep 100 &
+child=$!;
+wait $child`, path)
+}


### PR DESCRIPTION
This change updates `bpm` to allow regular files to specified in the
additional volumes configuration. Previously, this would fail due to the
fact that `bpm` attempts to `mkdir -p` all volumes specified. Now when
an additional volume is an existing file, `bpm` will only attempt to
`chown` the file to the vcap user and group.

This change also refactors the config validation logic to respect the
`BPM_BOSH_ROOT` environment variable.

This change also refactors the adapter's `CreateJobPrerequisites` to be
more readable.

[finishes #157259699](https://www.pivotaltracker.com/story/show/157259699)