### PR TITLE
Support adding volumes through flags on `bpm run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.10.0
 
+* allow users to specify additional volumes through flags on `bpm run`
 * allow users to specify regular files in `additional_volumes`
 * mount cgroup subsystems at canonical location
 

--- a/src/bpm/commands/run.go
+++ b/src/bpm/commands/run.go
@@ -26,8 +26,11 @@ import (
 	"bpm/runc/lifecycle"
 )
 
+var volumes []string
+
 func init() {
 	runCommand.Flags().StringVarP(&procName, "process", "p", "", "the optional process name")
+	runCommand.Flags().StringSliceVarP(&volumes, "volume", "v", []string{}, "Optional list of volumes (format: <path>[:<options>])")
 	RootCmd.AddCommand(runCommand)
 }
 
@@ -71,6 +74,11 @@ func run(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		logger.Error("process-not-defined", err)
 		return fmt.Errorf("process %q not present in job configuration (%s)", procName, bpmCfg.JobConfig())
+	}
+
+	if err = procCfg.AddVolumes(volumes, bosh.Root(), bpmCfg.DefaultVolumes()); err != nil {
+		logger.Error("invalid-volume-definition", err)
+		return err
 	}
 
 	runcLifecycle, err := newRuncLifecycle()

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -107,15 +107,17 @@ func (c *BPMConfig) JobConfig() string {
 	return filepath.Join(c.JobDir(), "config", "bpm.yml")
 }
 
+func (c *BPMConfig) DefaultVolumes() []string {
+	return []string{c.DataDir(), c.StoreDir()}
+}
+
 func (c *BPMConfig) ParseJobConfig() (*JobConfig, error) {
 	cfg, err := ParseJobConfig(c.JobConfig())
 	if err != nil {
 		return nil, err
 	}
 
-	defaultVolumes := []string{c.DataDir(), c.StoreDir()}
-
-	err = cfg.Validate(c.boshRoot, defaultVolumes)
+	err = cfg.Validate(c.boshRoot, c.DefaultVolumes())
 	if err != nil {
 		return nil, err
 	}

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -130,6 +130,44 @@ func (c *ProcessConfig) Validate(boshRoot string, defaultVolumes []string) error
 	return nil
 }
 
+func (c *ProcessConfig) AddVolumes(
+	volumes []string,
+	boshRoot string,
+	defaultVolumes []string,
+) error {
+	for _, volume := range volumes {
+		fields := strings.Split(volume, ":")
+
+		if len(fields) > 2 {
+			return fmt.Errorf("invalid volume definition (format: <path>[:<options>]): %s", volume)
+		}
+
+		v := Volume{
+			Path: fields[0],
+		}
+
+		if len(fields) == 2 {
+			options := strings.Split(fields[1], ",")
+			for _, option := range options {
+				switch option {
+				case "writable":
+					v.Writable = true
+				case "mount_only":
+					v.MountOnly = true
+				case "allow_executions":
+					v.AllowExecutions = true
+				default:
+					return fmt.Errorf("invalid volume option: %s", option)
+				}
+			}
+		}
+
+		c.AdditionalVolumes = append(c.AdditionalVolumes, v)
+	}
+
+	return c.Validate(boshRoot, defaultVolumes)
+}
+
 func contains(elements []string, s string) bool {
 	for _, elem := range elements {
 		if s == elem {


### PR DESCRIPTION
This change adds support for specifying volumes when using the `bpm run`
command. The format of a volume definition is `<path>[:<options>]` where
`<options>` is a comma separated list of: writable, mount_only,
allow_executions. The `--volume` or `-v` flag can be specified multiple
times to add more than one volume.

Fixes #74

[finishes #159472729]

I decided to add these volumes to `AdditionalVolumes` rather than `Unsafe.Volumes`. Also I chose not to validate that the volumes is within `/var/vcap/data` or `/var/vcap/store`. I can go either way on both of these decisions.