### PR TITLE
lifecycle: delete pidfile after job shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.0
+
+* delete the pidfile when the job is shutting down
+
 # v0.10.0
 
 * allow users to specify additional volumes through flags on `bpm run`

--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -186,6 +186,7 @@ func newRuncLifecycle() (*lifecycle.RuncLifecycle, error) {
 		userFinder,
 		lifecycle.NewCommandRunner(),
 		clock,
+		os.Remove,
 	), nil
 }
 

--- a/src/bpm/integration/stop_test.go
+++ b/src/bpm/integration/stop_test.go
@@ -92,6 +92,14 @@ var _ = Describe("stop", func() {
 		Eventually(fileContents(stdout)).Should(ContainSubstring("Received a Signal"))
 	})
 
+	It("removes the pid file", func() {
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+
+		Expect(filepath.Join(boshRoot, "sys", "run", "bpm", job, fmt.Sprintf("%s.pid", job))).ToNot(BeAnExistingFile())
+	})
+
 	It("removes the container and its corresponding process", func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
There's a chance that something else takes the PID after our job is
shutdown so monit thinks our job is still running and then eventually
times out when trying to stop it.

[fixes #159838818]