### PR TITLE
Fix bpm run env flag

### DIFF
--- a/src/bpm/commands/run.go
+++ b/src/bpm/commands/run.go
@@ -88,7 +88,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err = procCfg.AddEnvVars(volumes, bosh.Root(), bpmCfg.DefaultVolumes()); err != nil {
+	if err = procCfg.AddEnvVars(env, bosh.Root(), bpmCfg.DefaultVolumes()); err != nil {
 		logger.Error("invalid-environment-definition", err)
 		return err
 	}

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -177,6 +177,9 @@ func (c *ProcessConfig) AddEnvVars(
 	boshRoot string,
 	defaultVolumes []string,
 ) error {
+	if c.Env == nil {
+		c.Env = map[string]string{}
+	}
 	for _, e := range env {
 		parts := strings.SplitN(e, "=", 2)
 		if len(parts) < 2 {

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -280,7 +280,6 @@ var _ = Describe("Config", func() {
 			cfg = &config.ProcessConfig{
 				Name:       "name",
 				Executable: "executable",
-				Env:        map[string]string{},
 			}
 		})
 
@@ -310,6 +309,18 @@ var _ = Describe("Config", func() {
 					[]string{},
 				)
 				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when the process config has environment variables", func() {
+			It("adds the environment variables to the Env map", func() {
+				cfg.Env = map[string]string{"SIMPLE": "values"}
+
+				err := cfg.AddEnvVars([]string{"ANOTHER=value"}, "/bosh/root", []string{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(cfg.Env).To(HaveKeyWithValue("SIMPLE", "values"))
+				Expect(cfg.Env).To(HaveKeyWithValue("ANOTHER", "value"))
 			})
 		})
 	})


### PR DESCRIPTION
When tried to use the `-e` flag introduced to `bpm run` in v0.12.0 it failed and we found two issues:

1. the parsed `-v` flag was being passed to `config.ProcessConfig#AddEnvVars`. We could not find an existing test for this flag. Do you think we should?
1. the `Env` field of `config.ProcessConfig` is `nil` when none are specified in the config file, so we need to initialise the map before adding env vars from flags.

Josh and @aclevername
cc: @cloudfoundry-incubator/bosh-backup-and-restore-team 