### PR TITLE
Correctly parse environment and volumes on run

### DIFF
--- a/src/bpm/commands/run.go
+++ b/src/bpm/commands/run.go
@@ -36,8 +36,8 @@ var (
 
 func init() {
 	runCommand.Flags().StringVarP(&procName, "process", "p", "", "the optional process name")
-	runCommand.Flags().StringSliceVarP(&volumes, "volume", "v", []string{}, "Optional list of volumes (format: <path>[:<options>])")
-	runCommand.Flags().StringSliceVarP(&env, "env", "e", []string{}, "Additional environment variables (format: KEY=VALUE")
+	runCommand.Flags().StringArrayVarP(&volumes, "volume", "v", []string{}, "Optional list of volumes (format: <path>[:<options>])")
+	runCommand.Flags().StringArrayVarP(&env, "env", "e", []string{}, "Additional environment variables (format: KEY=VALUE")
 	RootCmd.AddCommand(runCommand)
 }
 

--- a/src/bpm/integration2/testdata/volume-flag.yml
+++ b/src/bpm/integration2/testdata/volume-flag.yml
@@ -1,0 +1,7 @@
+---
+processes:
+- name: errand
+  executable: /bin/bash
+  args:
+  - -c
+  - "cat /proc/mounts | grep extra-volume; echo success > $FILE_TO_WRITE_TO"


### PR DESCRIPTION
This change updates `bpm run` to not split both environment and volume
flags on commas. This is done by using the `StringArrayVarP` rather than
`StringSliceVarP`.

This change also adds an integration test for the volume and environment
flags on `bpm run`.

fixes #93

[finishes #159960525](https://www.pivotaltracker.com/story/show/159960525)