### PR TITLE
 integration: parse mount output rather than substring-ing

### DIFF
--- a/src/bpm/integration2/testdata/env-flag.yml
+++ b/src/bpm/integration2/testdata/env-flag.yml
@@ -1,0 +1,7 @@
+---
+processes:
+- name: errand
+  executable: /bin/bash
+  args:
+  - -c
+  - "echo $ENVKEY"

--- a/src/bpm/mount/mountutil_test.go
+++ b/src/bpm/mount/mountutil_test.go
@@ -16,6 +16,8 @@
 package mount
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -31,7 +33,7 @@ var _ = Describe("Mount", func() {
 
 	Describe("parseMountFile", func() {
 		It("returns a slice of mounts", func() {
-			mnts, err := parseMountFile("testdata/mount")
+			mnts, err := ParseFstab(fileContents("testdata/mount"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mnts).To(ConsistOf(
 				Mnt{
@@ -57,16 +59,15 @@ var _ = Describe("Mount", func() {
 
 		Context("when the file contains an invalid mount format", func() {
 			It("returns an error", func() {
-				_, err := parseMountFile("testdata/invalid-mount")
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("when the file doesn't exist", func() {
-			It("returns an error", func() {
-				_, err := parseMountFile("this-is-non-existant")
+				_, err := ParseFstab(fileContents("testdata/invalid-mount"))
 				Expect(err).To(HaveOccurred())
 			})
 		})
 	})
 })
+
+func fileContents(path string) []byte {
+	bs, err := ioutil.ReadFile(path)
+	Expect(err).ToNot(HaveOccurred())
+	return bs
+}


### PR DESCRIPTION
We saw test failures in some environments due to the string "rootfs" in
their mountpoint which unfortunately contains "ro". This led the tests
to believe that read-only option was set.

This change uses the newly exposed mount file parser to parse the output
which let's us write more precise assertions.