### PR TITLE
cgroups: only create the subsystem dir if missing

### DIFF
--- a/src/bpm/cgroups/cgroup.go
+++ b/src/bpm/cgroups/cgroup.go
@@ -170,11 +170,13 @@ func mountCgroupTmpfsIfNotPresent(mnts []mount.Mnt) error {
 
 func mountCgroupSubsystem(subsystem string) error {
 	mountPoint := filepath.Join(cgroupRoot, subsystem)
-	if err := os.MkdirAll(mountPoint, 0755); err != nil {
-		return err
-	}
-	if err := os.Chmod(mountPoint, 0755); err != nil {
-		return err
+	if _, err := os.Stat(mountPoint); os.IsNotExist(err) {
+		if err := os.MkdirAll(mountPoint, 0755); err != nil {
+			return err
+		}
+		if err := os.Chmod(mountPoint, 0755); err != nil {
+			return err
+		}
 	}
 
 	err := mount.Mount("cgroup", mountPoint, "cgroup", 0, subsystem)


### PR DESCRIPTION
This was an issue on centOS stemcells which mount /sys/fs/cgroups
read-only. This doesn't stop us from mounting on top of it but it does
prevent us creating the backing directory for those mounts. Fortunately,
the directory probably already exists.