### PR TITLE
runc/client: ignore child process stderr

### DIFF
--- a/src/bpm/runc/client/client.go
+++ b/src/bpm/runc/client/client.go
@@ -183,7 +183,7 @@ func (c *RuncClient) ListContainers() ([]ContainerState, error) {
 		"--format", "json",
 	)
 
-	data, err := runcCmd.CombinedOutput()
+	data, err := runcCmd.Output()
 	if err != nil {
 		return []ContainerState{}, err
 	}


### PR DESCRIPTION
RunC has a race where a newly created container will appear in the
list output before it is ready to have its state collected. This results
in an error being emitted to stderr before the rest of the list is
written as normal. Due to us using CombinedOutput() we were also trying
to parse this non-JSON error as JSON which caused the command to error.

This change also changes the fixture test permissions from 0777 to 0700.