### PR TITLE
config: allow volumes to be in /var/vcap/sys/run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.13.0
+
+* volumes can be mounted inside `/var/vcap/sys/run`
+
 # v0.12.3
 
 * do not try and create cgroup directories if they already exist

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,20 +34,20 @@ directory of your job.
 
 #### `process` Schema
 
-| **Property**         | **Type**         | **Required?** | **Description**                                                                                                                   |
-| -------------------- | ---------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | string           | Yes           | The name of this process.                                                                                                         |
-| `executable`         | string           | Yes           | The path to the executable file for this process.                                                                                 |
-| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                                                           |
-| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.                                           |
-| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.                                  |
-| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                                                              |
-| `capabilities`       | string[]         | No            | The list of [capabilities][capabilities] (without CAP_) which should be granted to this process.                                  |
-| `limits`             | limits           | No            | The limit configuration for this process (see below).                                                                             |
-| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.                                    |
-| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.                                  |
-| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process (see below). They must be inside `/var/vcap/data` or `/var/vcap/store`. |
-| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                                                            |
+| **Property**         | **Type**         | **Required?** | **Description**                                                                                                                |
+| -------------------- | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `name`               | string           | Yes           | The name of this process.                                                                                                      |
+| `executable`         | string           | Yes           | The path to the executable file for this process.                                                                              |
+| `args`               | string[]         | No            | The arguments which will be passed to the `executable` of this process.                                                        |
+| `env`                | string => string | No            | Any additional environment variables to be included in the environment of this process.                                        |
+| `workdir`            | string           | No            | The working directory for this process. If not specified this is the value `/var/vcap/jobs/JOB`.                               |
+| `hooks`              | hooks            | No            | The hook configuration for this process (see below).                                                                           |
+| `capabilities`       | string[]         | No            | The list of [capabilities][capabilities] (without CAP_) which should be granted to this process.                               |
+| `limits`             | limits           | No            | The limit configuration for this process (see below).                                                                          |
+| `ephemeral_disk`     | boolean          | No            | Whether or not an ephemeral disk should be mounted into the container at `/var/vcap/data/JOB`.                                 |
+| `persistent_disk`    | boolean          | No            | Whether or not an persistent disk should be mounted into the container at `/var/vcap/store/JOB`.                               |
+| `additional_volumes` | volume[]         | No            | A list of additional volumes to mount inside this process. The paths which can be used are restricted (see volume note below). |
+| `unsafe`             | unsafe           | No            | The unsafe configuration for this process (see below).                                                                         |
 
 [capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
 
@@ -81,6 +81,9 @@ directory of your job.
 | `allow_executions` | boolean  | No           | Whether or not executable files can be executed from this volume.                                              |
 | `mount_only`       | boolean  | No           | Whether or not BPM should just mount this directory rather than creating and chowning a backing directory too. |
 
+*Note: The volumes in additional volumes must have a path inside
+`/var/vcap/data`, `/var/vcap/store`, `/var/vcap/sys/run`. If you need to mount
+a volume outside these paths then you must use the `unrestricted_volumes` key.
 
 ### Example
 

--- a/src/bpm/config/bpm_config.go
+++ b/src/bpm/config/bpm_config.go
@@ -63,6 +63,10 @@ func (c *BPMConfig) StoreDir() string {
 	return filepath.Join(c.boshRoot, "store", c.jobName)
 }
 
+func (c *BPMConfig) SocketDir() string {
+	return filepath.Join(c.boshRoot, "sys", "run", c.jobName)
+}
+
 func (c *BPMConfig) TempDir() string {
 	return filepath.Join(c.DataDir(), "tmp")
 }

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Config", func() {
 						AdditionalVolumes: []config.Volume{
 							{Path: "/var/vcap/data/valid"},
 							{Path: "/var/vcap/store/valid"},
+							{Path: "/var/vcap/sys/run/valid"},
 						},
 					},
 				},

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -79,6 +79,7 @@ func (a *RuncAdapter) CreateJobPrerequisites(
 	dirsToCreate = append(
 		dirsToCreate,
 		bpmCfg.LogDir(),
+		bpmCfg.SocketDir(),
 		bpmCfg.TempDir(),
 	)
 

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -100,6 +100,13 @@ var _ = Describe("RuncAdapter", func() {
 			Expect(logDirInfo.Sys().(*syscall.Stat_t).Uid).To(Equal(uint32(200)))
 			Expect(logDirInfo.Sys().(*syscall.Stat_t).Gid).To(Equal(uint32(300)))
 
+			// Log Directory
+			socketDirInfo, err := os.Stat(bpmCfg.SocketDir())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(socketDirInfo.Mode() & os.ModePerm).To(Equal(os.FileMode(0700)))
+			Expect(socketDirInfo.Sys().(*syscall.Stat_t).Uid).To(Equal(uint32(200)))
+			Expect(socketDirInfo.Sys().(*syscall.Stat_t).Gid).To(Equal(uint32(300)))
+
 			// Stdout Log File
 			Expect(stdout.Name()).To(Equal(bpmCfg.Stdout()))
 			stdoutInfo, err := stdout.Stat()


### PR DESCRIPTION
This path is the de-facto location of job sockets. This helps
socket-using releases migrate to BPM without needing to conditionally
move their sockets to /var/vcap/data which can be a pain for consumers.

[finishes #160845685] (fixes #104)