### PR TITLE
Base32-encode only invalid runc format substrings

### DIFF
--- a/src/bpm/commands/list.go
+++ b/src/bpm/commands/list.go
@@ -18,6 +18,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -99,5 +100,6 @@ func updateProcess(processes []*models.Process, process *models.Process) ([]*mod
 	if err != nil {
 		return processes, err
 	}
+	decodedName = strings.TrimPrefix(decodedName, config.ContainerPrefix)
 	return processes, fmt.Errorf("process (%s) not defined", decodedName)
 }

--- a/src/bpm/integration/capabilities_test.go
+++ b/src/bpm/integration/capabilities_test.go
@@ -49,7 +49,7 @@ var _ = Describe("capabilities", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "capabiliteis-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/list_test.go
+++ b/src/bpm/integration/list_test.go
@@ -55,10 +55,10 @@ var _ = Describe("list", func() {
 
 		// This forces the ordering from runc list to be consistent.
 		job = fmt.Sprintf("started-%s", uuid.NewV4().String())
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 
 		failedJob = fmt.Sprintf("failed-%s", uuid.NewV4().String())
-		failedContainerID = config.Encode(failedJob)
+		failedContainerID = config.ContainerPrefix + config.Encode(failedJob)
 
 		stoppedProcess = fmt.Sprintf("stopped-%s", uuid.NewV4().String())
 

--- a/src/bpm/integration/logs_test.go
+++ b/src/bpm/integration/logs_test.go
@@ -49,7 +49,7 @@ var _ = Describe("logs", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "logs-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
@@ -231,7 +231,7 @@ var _ = Describe("logs", func() {
 
 		BeforeEach(func() {
 			process = uuid.NewV4().String()
-			otherContainerID = config.Encode(process)
+			otherContainerID = config.ContainerPrefix + config.Encode(process)
 
 			cfg.Processes = append(cfg.Processes, &config.ProcessConfig{
 				Name:       process,

--- a/src/bpm/integration/namespaces_test.go
+++ b/src/bpm/integration/namespaces_test.go
@@ -49,7 +49,7 @@ var _ = Describe("start", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/pid_test.go
+++ b/src/bpm/integration/pid_test.go
@@ -47,7 +47,7 @@ var _ = Describe("pid", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "pid-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/privileged_test.go
+++ b/src/bpm/integration/privileged_test.go
@@ -47,7 +47,7 @@ var _ = Describe("privileged containers", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -50,7 +50,7 @@ var _ = Describe("resource limits", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "resource-limits-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/shell_test.go
+++ b/src/bpm/integration/shell_test.go
@@ -51,7 +51,7 @@ var _ = Describe("start", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/start_stop_parallelization_test.go
+++ b/src/bpm/integration/start_stop_parallelization_test.go
@@ -43,7 +43,7 @@ var _ = Describe("start / stop parallelization", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-stop-parallelization-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/start_test.go
+++ b/src/bpm/integration/start_test.go
@@ -53,7 +53,7 @@ var _ = Describe("start", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())
@@ -143,7 +143,7 @@ var _ = Describe("start", func() {
 
 		BeforeEach(func() {
 			process = uuid.NewV4().String()
-			containerID = config.Encode(fmt.Sprintf("%s.%s", job, process))
+			containerID = config.ContainerPrefix + config.Encode(fmt.Sprintf("%s.%s", job, process))
 
 			cfg.Processes = append(cfg.Processes, &config.ProcessConfig{
 				Name:       process,

--- a/src/bpm/integration/stop_test.go
+++ b/src/bpm/integration/stop_test.go
@@ -50,7 +50,7 @@ var _ = Describe("stop", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "stop-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/integration/trace_test.go
+++ b/src/bpm/integration/trace_test.go
@@ -47,7 +47,7 @@ var _ = Describe("trace", func() {
 		var err error
 
 		job = uuid.NewV4().String()
-		containerID = config.Encode(job)
+		containerID = config.ContainerPrefix + config.Encode(job)
 		boshRoot, err = ioutil.TempDir(bpmTmpDir, "start-test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chmod(boshRoot, 0755)).To(Succeed())

--- a/src/bpm/presenters/presenters.go
+++ b/src/bpm/presenters/presenters.go
@@ -35,6 +35,7 @@ func PrintJobs(processes []*models.Process, stdout io.Writer) error {
 		if err != nil {
 			return err
 		}
+		name = strings.TrimPrefix(name, config.ContainerPrefix)
 
 		pid := "-"
 		if process.Pid > 0 {

--- a/src/bpm/runc/lifecycle/lifecycle_test.go
+++ b/src/bpm/runc/lifecycle/lifecycle_test.go
@@ -92,7 +92,7 @@ var _ = Describe("RuncJobLifecycle", func() {
 
 		expectedJobName = "example"
 		expectedProcName = "server"
-		expectedContainerID = config.Encode(fmt.Sprintf("%s.%s", expectedJobName, expectedProcName))
+		expectedContainerID = config.ContainerPrefix + config.Encode(fmt.Sprintf("%s.%s", expectedJobName, expectedProcName))
 
 		procCfg = &config.ProcessConfig{
 			Executable: "/bin/sleep",
@@ -180,7 +180,7 @@ var _ = Describe("RuncJobLifecycle", func() {
 
 				Expect(fakeRuncClient.RunContainerCallCount()).To(Equal(1))
 				_, _, cid, _, _, _ := fakeRuncClient.RunContainerArgsForCall(0)
-				Expect(cid).To(Equal(config.Encode(expectedJobName)))
+				Expect(cid).To(Equal(config.ContainerPrefix + config.Encode(expectedJobName)))
 			})
 		})
 
@@ -534,7 +534,7 @@ var _ = Describe("RuncJobLifecycle", func() {
 
 				Expect(fakeRuncClient.DeleteContainerCallCount()).To(Equal(1))
 				containerID := fakeRuncClient.DeleteContainerArgsForCall(0)
-				Expect(containerID).To(Equal(config.Encode(expectedJobName)))
+				Expect(containerID).To(Equal(config.ContainerPrefix + config.Encode(expectedJobName)))
 			})
 		})
 
@@ -654,7 +654,7 @@ var _ = Describe("RuncJobLifecycle", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeRuncClient.ContainerStateCallCount()).To(Equal(1))
-				Expect(fakeRuncClient.ContainerStateArgsForCall(0)).To(Equal(config.Encode(expectedJobName)))
+				Expect(fakeRuncClient.ContainerStateArgsForCall(0)).To(Equal(config.ContainerPrefix + config.Encode(expectedJobName)))
 			})
 		})
 
@@ -719,7 +719,7 @@ var _ = Describe("RuncJobLifecycle", func() {
 
 				Expect(fakeRuncClient.ExecCallCount()).To(Equal(1))
 				cid, _, _, _, _ := fakeRuncClient.ExecArgsForCall(0)
-				Expect(cid).To(Equal(config.Encode(expectedJobName)))
+				Expect(cid).To(Equal(config.ContainerPrefix + config.Encode(expectedJobName)))
 			})
 		})
 


### PR DESCRIPTION
Also, prepend "bpm-" to the container ID.

Close #109