### PR TITLE
client: do not write pidfile for "bpm run"

### DIFF
--- a/src/bpm/integration2/run_test.go
+++ b/src/bpm/integration2/run_test.go
@@ -70,6 +70,7 @@ func TestRun(t *testing.T) {
 	if contents, sentinel := string(output), "stderr"; !strings.Contains(contents, sentinel) {
 		t.Errorf("stdout/stderr did not contain %q, contents: %q", sentinel, contents)
 	}
+
 	stdout, err := ioutil.ReadFile(s.Path("sys", "log", "errand", "errand.stdout.log"))
 	if err != nil {
 		t.Fatalf("failed to read stdout log: %v", err)
@@ -77,12 +78,18 @@ func TestRun(t *testing.T) {
 	if contents, sentinel := string(stdout), "stdout"; !strings.Contains(contents, sentinel) {
 		t.Errorf("stdout log file did not contain %q, contents: %q", sentinel, contents)
 	}
+
 	stderr, err := ioutil.ReadFile(s.Path("sys", "log", "errand", "errand.stderr.log"))
 	if err != nil {
 		t.Fatalf("failed to read stderr log: %v", err)
 	}
 	if contents, sentinel := string(stderr), "stderr"; !strings.Contains(contents, sentinel) {
 		t.Errorf("stderr log file did not contain %q, contents: %q", sentinel, contents)
+	}
+
+	pidfile := s.Path("sys", "run", "bpm", "errand", "errand.pid")
+	if _, err := os.Stat(pidfile); !os.IsNotExist(err) {
+		t.Errorf("expected %q not to exist but it did", pidfile)
 	}
 }
 

--- a/src/bpm/runc/client/client.go
+++ b/src/bpm/runc/client/client.go
@@ -102,9 +102,9 @@ func (*RuncClient) CreateBundle(
 func (c *RuncClient) RunContainer(pidFilePath, bundlePath, containerID string, detach bool, stdout, stderr io.Writer) (int, error) {
 	args := []string{
 		"--bundle", bundlePath,
-		"--pid-file", pidFilePath,
 	}
 	if detach {
+		args = append(args, "--pid-file", pidFilePath)
 		args = append(args, "--detach")
 	}
 	args = append(args, containerID)


### PR DESCRIPTION
Writing a pidfile is not necessary for "bpm run" as the job stays in the
foreground. This also meant that we never cleaned these pidfiles up and
so they would (harmlessly, but untidily) leak onto the system.

The `bpm pid` command will still work as it queries runc directly rather
than reading this file.

[fixes #163704234]