### PR TITLE
disable seccomp for emulated environments

### DIFF
--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -296,6 +296,11 @@ func (a *RuncAdapter) BuildSpec(
 		specbuilder.Apply(spec, specbuilder.WithNamespace("pid"))
 	}
 
+	// Disable seccomp if not supported (e.g., architecture emulation)
+	if !a.features.SeccompSupported {
+		specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+	}
+
 	if procCfg.Unsafe != nil && procCfg.Unsafe.Privileged {
 		specbuilder.Apply(spec, specbuilder.WithPrivileged())
 	}

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -296,7 +296,6 @@ func (a *RuncAdapter) BuildSpec(
 		specbuilder.Apply(spec, specbuilder.WithNamespace("pid"))
 	}
 
-	// Disable seccomp if not supported (e.g., architecture emulation)
 	if !a.features.SeccompSupported {
 		specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
 	}

--- a/src/bpm/runc/specbuilder/specbuilder.go
+++ b/src/bpm/runc/specbuilder/specbuilder.go
@@ -190,6 +190,17 @@ var RootUser = specs.User{
 	GID: 0,
 }
 
+// WithoutSeccomp disables seccomp filtering. This is needed when running
+// in environments where seccomp BPF filters cannot be loaded (e.g., when
+// running x86_64 binaries on an ARM64 kernel via Rosetta emulation).
+// Unlike WithPrivileged(), this only disables seccomp without granting
+// additional privileges or removing other security features.
+func WithoutSeccomp() SpecOption {
+	return func(spec *specs.Spec) {
+		spec.Linux.Seccomp = nil
+	}
+}
+
 func WithPrivileged() SpecOption {
 	return func(spec *specs.Spec) {
 		Apply(spec, WithCapabilities(DefaultPrivilegedCapabilities()))

--- a/src/bpm/runc/specbuilder/specbuilder_test.go
+++ b/src/bpm/runc/specbuilder/specbuilder_test.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2018-Present CloudFoundry.org Foundation, Inc. All rights reserved.
+//
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package specbuilder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"bpm/runc/specbuilder"
+)
+
+func TestSpecbuilder(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Specbuilder Suite")
+}
+
+var _ = Describe("SpecBuilder", func() {
+	Describe("WithoutSeccomp", func() {
+		var spec *specs.Spec
+
+		BeforeEach(func() {
+			spec = specbuilder.DefaultSpec()
+		})
+
+		It("removes seccomp from the spec", func() {
+			Expect(spec.Linux.Seccomp).NotTo(BeNil())
+
+			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+
+			Expect(spec.Linux.Seccomp).To(BeNil())
+		})
+
+		It("does not affect other security features", func() {
+			// Capture original values
+			originalNoNewPrivileges := spec.Process.NoNewPrivileges
+			originalMaskedPaths := spec.Linux.MaskedPaths
+			originalReadonlyPaths := spec.Linux.ReadonlyPaths
+			originalUser := spec.Process.User
+
+			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+
+			// Verify other security features are unchanged
+			Expect(spec.Process.NoNewPrivileges).To(Equal(originalNoNewPrivileges))
+			Expect(spec.Linux.MaskedPaths).To(Equal(originalMaskedPaths))
+			Expect(spec.Linux.ReadonlyPaths).To(Equal(originalReadonlyPaths))
+			Expect(spec.Process.User).To(Equal(originalUser))
+		})
+
+		It("does not affect capabilities", func() {
+			// Add some capabilities
+			specbuilder.Apply(spec, specbuilder.WithCapabilities([]string{"CAP_NET_BIND_SERVICE"}))
+			
+			originalCaps := spec.Process.Capabilities
+
+			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+
+			// Verify capabilities are unchanged
+			Expect(spec.Process.Capabilities).To(Equal(originalCaps))
+		})
+
+		It("does not affect user settings", func() {
+			testUser := specs.User{UID: 1000, GID: 1000}
+			specbuilder.Apply(spec, specbuilder.WithUser(testUser))
+
+			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+
+			Expect(spec.Process.User).To(Equal(testUser))
+		})
+
+		It("does not affect mount options", func() {
+			// Check that nosuid is still present on mounts
+			var hasMountWithNosuid bool
+			for _, mount := range spec.Mounts {
+				for _, opt := range mount.Options {
+					if opt == "nosuid" {
+						hasMountWithNosuid = true
+						break
+					}
+				}
+			}
+
+			Expect(hasMountWithNosuid).To(BeTrue(), "Expected at least one mount to have nosuid option")
+
+			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+
+			// Verify nosuid is still present after WithoutSeccomp
+			hasMountWithNosuid = false
+			for _, mount := range spec.Mounts {
+				for _, opt := range mount.Options {
+					if opt == "nosuid" {
+						hasMountWithNosuid = true
+						break
+					}
+				}
+			}
+
+			Expect(hasMountWithNosuid).To(BeTrue(), "Expected nosuid to remain on mounts")
+		})
+
+		Context("when applied before WithPrivileged", func() {
+			It("WithPrivileged still removes seccomp", func() {
+				specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+				Expect(spec.Linux.Seccomp).To(BeNil())
+
+				specbuilder.Apply(spec, specbuilder.WithPrivileged())
+				Expect(spec.Linux.Seccomp).To(BeNil())
+			})
+		})
+
+		Context("when applied after WithPrivileged", func() {
+			It("seccomp remains nil", func() {
+				specbuilder.Apply(spec, specbuilder.WithPrivileged())
+				Expect(spec.Linux.Seccomp).To(BeNil())
+
+				specbuilder.Apply(spec, specbuilder.WithoutSeccomp())
+				Expect(spec.Linux.Seccomp).To(BeNil())
+			})
+		})
+	})
+
+	Describe("DefaultSpec", func() {
+		It("includes seccomp by default", func() {
+			spec := specbuilder.DefaultSpec()
+			Expect(spec.Linux.Seccomp).NotTo(BeNil())
+			Expect(spec.Linux.Seccomp.Architectures).NotTo(BeEmpty())
+			Expect(spec.Linux.Seccomp.Syscalls).NotTo(BeEmpty())
+		})
+	})
+})

--- a/src/bpm/runc/specbuilder/specbuilder_test.go
+++ b/src/bpm/runc/specbuilder/specbuilder_test.go
@@ -65,7 +65,7 @@ var _ = Describe("SpecBuilder", func() {
 		It("does not affect capabilities", func() {
 			// Add some capabilities
 			specbuilder.Apply(spec, specbuilder.WithCapabilities([]string{"CAP_NET_BIND_SERVICE"}))
-			
+
 			originalCaps := spec.Process.Capabilities
 
 			specbuilder.Apply(spec, specbuilder.WithoutSeccomp())

--- a/src/bpm/sysfeat/sysfeat.go
+++ b/src/bpm/sysfeat/sysfeat.go
@@ -19,7 +19,10 @@ package sysfeat
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/opencontainers/cgroups"
 )
@@ -32,10 +35,25 @@ const (
 	hybridMountpoint  = "/sys/fs/cgroup/unified"
 )
 
+// goArchToKernelArch maps Go's GOARCH values to Linux kernel architecture
+// names as returned by `uname -m`. This mapping is used to detect when
+// a binary is running under architecture emulation (e.g., x86_64 binaries
+// on ARM64 kernels via Rosetta).
+var goArchToKernelArch = map[string]string{
+	"amd64": "x86_64",
+	"386":   "i686",
+	"arm64": "aarch64",
+	"arm":   "armv7l",
+}
+
 // Features contains information about what features the host system supports.
 type Features struct {
 	// Whether the system supports limiting the swap space of a process or not.
 	SwapLimitSupported bool
+	// Whether the system supports seccomp BPF filtering. This may be false in
+	// environments with architecture emulation (e.g., x86_64 binaries running
+	// on ARM64 kernels via Rosetta).
+	SeccompSupported bool
 }
 
 func Fetch() (*Features, error) {
@@ -46,6 +64,7 @@ func Fetch() (*Features, error) {
 
 	return &Features{
 		SwapLimitSupported: supported,
+		SeccompSupported:   seccompSupported(),
 	}, nil
 }
 
@@ -78,4 +97,80 @@ func swapLimitSupportedCgroup1() (bool, error) {
 
 	_, err = os.Stat(filepath.Join(mountPoint, swapPathCgroup1))
 	return err == nil, nil
+}
+
+// seccompSupported checks whether seccomp BPF filtering is supported in the
+// current environment. It returns false when running in a container with
+// architecture emulation (e.g., x86_64 binaries on ARM64 kernels).
+func seccompSupported() bool {
+	// Allow override to force seccomp enabled even in emulated environments
+	if os.Getenv("BPM_DISABLE_SECCOMP_DETECTION") != "" {
+		return true
+	}
+
+	// If not in a container, seccomp works normally
+	if !isRunningInContainer() {
+		return true
+	}
+
+	// Check if Go binary architecture matches kernel architecture
+	goArch := runtime.GOARCH          // e.g., "amd64"
+	kernelArch := getKernelArch()     // e.g., "x86_64"
+
+	expectedKernelArch, ok := goArchToKernelArch[goArch]
+	if !ok {
+		// Unknown architecture mapping, assume seccomp works (conservative)
+		return true
+	}
+
+	// If architectures don't match, we're under emulation
+	// Seccomp BPF filters won't work
+	if kernelArch != expectedKernelArch {
+		return false
+	}
+
+	return true
+}
+
+// isRunningInContainer checks whether the current process is running inside
+// a container environment.
+func isRunningInContainer() bool {
+	// Check for /.dockerenv
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	// Check systemd-detect-virt -c
+	cmd := exec.Command("systemd-detect-virt", "-c")
+	output, err := cmd.Output()
+	if err == nil {
+		result := strings.TrimSpace(string(output))
+		if result != "none" && result != "" {
+			return true
+		}
+	}
+
+	// Check /proc/1/cgroup for container indicators
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") ||
+			strings.Contains(content, "lxc") ||
+			strings.Contains(content, "kubepods") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getKernelArch returns the kernel architecture using uname -m.
+func getKernelArch() string {
+	cmd := exec.Command("uname", "-m")
+	output, err := cmd.Output()
+	if err != nil {
+		// If we can't determine the kernel arch, assume it matches (conservative)
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/src/bpm/sysfeat/sysfeat.go
+++ b/src/bpm/sysfeat/sysfeat.go
@@ -114,8 +114,8 @@ func seccompSupported() bool {
 	}
 
 	// Check if Go binary architecture matches kernel architecture
-	goArch := runtime.GOARCH          // e.g., "amd64"
-	kernelArch := getKernelArch()     // e.g., "x86_64"
+	goArch := runtime.GOARCH      // e.g., "amd64"
+	kernelArch := getKernelArch() // e.g., "x86_64"
 
 	expectedKernelArch, ok := goArchToKernelArch[goArch]
 	if !ok {

--- a/src/bpm/sysfeat/sysfeat.go
+++ b/src/bpm/sysfeat/sysfeat.go
@@ -19,10 +19,7 @@ package sysfeat
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/opencontainers/cgroups"
 )
@@ -33,26 +30,18 @@ const (
 
 	unifiedMountpoint = "/sys/fs/cgroup"
 	hybridMountpoint  = "/sys/fs/cgroup/unified"
-)
 
-// goArchToKernelArch maps Go's GOARCH values to Linux kernel architecture
-// names as returned by `uname -m`. This mapping is used to detect when
-// a binary is running under architecture emulation (e.g., x86_64 binaries
-// on ARM64 kernels via Rosetta).
-var goArchToKernelArch = map[string]string{
-	"amd64": "x86_64",
-	"386":   "i686",
-	"arm64": "aarch64",
-	"arm":   "armv7l",
-}
+	rosettaBinfmtPath = "/proc/sys/fs/binfmt_misc/rosetta"
+)
 
 // Features contains information about what features the host system supports.
 type Features struct {
 	// Whether the system supports limiting the swap space of a process or not.
 	SwapLimitSupported bool
-	// Whether the system supports seccomp BPF filtering. This may be false in
-	// environments with architecture emulation (e.g., x86_64 binaries running
-	// on ARM64 kernels via Rosetta).
+	// Whether the system supports seccomp BPF filtering. This is false when
+	// Rosetta binfmt_misc translation is registered, because seccomp BPF
+	// filters are architecture-specific and will not work correctly under
+	// Rosetta's x86_64-on-ARM64 emulation.
 	SeccompSupported bool
 }
 
@@ -99,114 +88,13 @@ func swapLimitSupportedCgroup1() (bool, error) {
 	return err == nil, nil
 }
 
-// seccompSupported checks whether seccomp BPF filtering is supported in the
-// current environment. It returns false when running in a container with
-// architecture emulation (e.g., x86_64 binaries on ARM64 kernels).
+// seccompSupported returns false when Rosetta binfmt_misc translation is
+// registered on the host. This is the only scenario where BPM needs to
+// disable seccomp: Colima (or similar) VMs on Apple Silicon register
+// /proc/sys/fs/binfmt_misc/rosetta so that x86_64 binaries can run on the
+// ARM64 kernel, but seccomp BPF filters are architecture-specific and will
+// reject the translated syscalls.
 func seccompSupported() bool {
-	// Allow override to force seccomp disabled in emulated environments
-	if os.Getenv("BPM_FORCE_DISABLE_SECCOMP") != "" {
-		return false
-	}
-
-	// Allow override to force seccomp enabled even in emulated environments
-	if os.Getenv("BPM_DISABLE_SECCOMP_DETECTION") != "" {
-		return true
-	}
-
-	// Check if running under Rosetta emulation on Apple Silicon
-	// This is the most reliable detection because Rosetta intercepts uname
-	// and lies to x86 binaries about the kernel architecture.
-	if isRunningUnderRosetta() {
-		return false
-	}
-
-	// If not in a container, seccomp works normally
-	if !isRunningInContainer() {
-		return true
-	}
-
-	// Check if Go binary architecture matches kernel architecture
-	goArch := runtime.GOARCH      // e.g., "amd64"
-	kernelArch := getKernelArch() // e.g., "x86_64"
-
-	expectedKernelArch, ok := goArchToKernelArch[goArch]
-	if !ok {
-		// Unknown architecture mapping, assume seccomp works (conservative)
-		return true
-	}
-
-	// If architectures don't match, we're under emulation
-	// Seccomp BPF filters won't work
-	if kernelArch != expectedKernelArch {
-		return false
-	}
-
-	return true
-}
-
-// isRunningUnderRosetta detects if we're running under Apple's Rosetta
-// translation layer on Apple Silicon. Rosetta intercepts the uname syscall
-// and returns "x86_64" to x86 binaries even though the kernel is actually
-// ARM64 (aarch64). This breaks seccomp BPF filters because they're
-// architecture-specific.
-func isRunningUnderRosetta() bool {
-	// Check if rosetta is registered in binfmt_misc
-	// This is a reliable indicator that we're on a system with Rosetta
-	if _, err := os.Stat("/proc/sys/fs/binfmt_misc/rosetta"); err == nil {
-		return true
-	}
-
-	// Check /proc/cpuinfo for VirtualApple vendor
-	// This indicates Apple Silicon virtualization/emulation
-	data, err := os.ReadFile("/proc/cpuinfo")
-	if err == nil {
-		if strings.Contains(string(data), "VirtualApple") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isRunningInContainer checks whether the current process is running inside
-// a container environment.
-func isRunningInContainer() bool {
-	// Check for /.dockerenv
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-
-	// Check systemd-detect-virt -c
-	cmd := exec.Command("systemd-detect-virt", "-c")
-	output, err := cmd.Output()
-	if err == nil {
-		result := strings.TrimSpace(string(output))
-		if result != "none" && result != "" {
-			return true
-		}
-	}
-
-	// Check /proc/1/cgroup for container indicators
-	data, err := os.ReadFile("/proc/1/cgroup")
-	if err == nil {
-		content := string(data)
-		if strings.Contains(content, "docker") ||
-			strings.Contains(content, "lxc") ||
-			strings.Contains(content, "kubepods") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// getKernelArch returns the kernel architecture using uname -m.
-func getKernelArch() string {
-	cmd := exec.Command("uname", "-m")
-	output, err := cmd.Output()
-	if err != nil {
-		// If we can't determine the kernel arch, assume it matches (conservative)
-		return ""
-	}
-	return strings.TrimSpace(string(output))
+	_, err := os.Stat(rosettaBinfmtPath)
+	return err != nil
 }

--- a/src/bpm/sysfeat/sysfeat_test.go
+++ b/src/bpm/sysfeat/sysfeat_test.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2018-Present CloudFoundry.org Foundation, Inc. All rights reserved.
+//
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package sysfeat_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"bpm/sysfeat"
+)
+
+func TestSysfeat(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sysfeat Suite")
+}
+
+var _ = Describe("Features", func() {
+	Describe("Fetch", func() {
+		It("returns a Features struct", func() {
+			features, err := sysfeat.Fetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(features).NotTo(BeNil())
+		})
+
+		It("includes SeccompSupported field", func() {
+			features, err := sysfeat.Fetch()
+			Expect(err).NotTo(HaveOccurred())
+			// On native systems, seccomp should be supported
+			// We can't assert the exact value as it depends on the environment
+			// but we can verify the field exists and has a boolean value
+			_ = features.SeccompSupported
+		})
+
+		Context("when BPM_DISABLE_SECCOMP_DETECTION is set", func() {
+			BeforeEach(func() {
+				os.Setenv("BPM_DISABLE_SECCOMP_DETECTION", "1")
+			})
+
+			AfterEach(func() {
+				os.Unsetenv("BPM_DISABLE_SECCOMP_DETECTION")
+			})
+
+			It("forces SeccompSupported to true", func() {
+				features, err := sysfeat.Fetch()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features.SeccompSupported).To(BeTrue())
+			})
+		})
+
+		Context("on a native system", func() {
+			It("reports seccomp as supported", func() {
+				// This test assumes we're running on a native system (not in an
+				// emulated container). In CI/CD environments, this should be true.
+				features, err := sysfeat.Fetch()
+				Expect(err).NotTo(HaveOccurred())
+
+				// If we're not in a container, seccomp should always be supported
+				// We can check this by verifying we're not in a container
+				// (no /.dockerenv file)
+				_, dockerEnvErr := os.Stat("/.dockerenv")
+				if os.IsNotExist(dockerEnvErr) {
+					// Not in a container, seccomp should be supported
+					Expect(features.SeccompSupported).To(BeTrue())
+				}
+			})
+		})
+	})
+
+	Describe("Architecture detection", func() {
+		It("correctly identifies the current architecture", func() {
+			// This is more of a smoke test to ensure the architecture
+			// detection doesn't panic or return unexpected values
+			goArch := runtime.GOARCH
+			Expect(goArch).NotTo(BeEmpty())
+
+			// Common architectures we expect
+			validArchs := []string{"amd64", "386", "arm64", "arm"}
+			Expect(validArchs).To(ContainElement(goArch))
+		})
+	})
+})

--- a/src/bpm/sysfeat/sysfeat_test.go
+++ b/src/bpm/sysfeat/sysfeat_test.go
@@ -50,11 +50,13 @@ var _ = Describe("Features", func() {
 
 		Context("when BPM_DISABLE_SECCOMP_DETECTION is set", func() {
 			BeforeEach(func() {
-				os.Setenv("BPM_DISABLE_SECCOMP_DETECTION", "1")
+				err := os.Setenv("BPM_DISABLE_SECCOMP_DETECTION", "1")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
-				os.Unsetenv("BPM_DISABLE_SECCOMP_DETECTION")
+				err := os.Unsetenv("BPM_DISABLE_SECCOMP_DETECTION")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("forces SeccompSupported to true", func() {

--- a/src/bpm/sysfeat/sysfeat_test.go
+++ b/src/bpm/sysfeat/sysfeat_test.go
@@ -17,7 +17,6 @@ package sysfeat_test
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -42,59 +41,20 @@ var _ = Describe("Features", func() {
 		It("includes SeccompSupported field", func() {
 			features, err := sysfeat.Fetch()
 			Expect(err).NotTo(HaveOccurred())
-			// On native systems, seccomp should be supported
-			// We can't assert the exact value as it depends on the environment
-			// but we can verify the field exists and has a boolean value
 			_ = features.SeccompSupported
 		})
 
-		Context("when BPM_DISABLE_SECCOMP_DETECTION is set", func() {
-			BeforeEach(func() {
-				err := os.Setenv("BPM_DISABLE_SECCOMP_DETECTION", "1")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		Context("when Rosetta binfmt_misc is not registered", func() {
+			It("reports seccomp as supported", func() {
+				_, err := os.Stat("/proc/sys/fs/binfmt_misc/rosetta")
+				if !os.IsNotExist(err) {
+					Skip("Rosetta binfmt_misc is registered on this host")
+				}
 
-			AfterEach(func() {
-				err := os.Unsetenv("BPM_DISABLE_SECCOMP_DETECTION")
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("forces SeccompSupported to true", func() {
 				features, err := sysfeat.Fetch()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(features.SeccompSupported).To(BeTrue())
 			})
-		})
-
-		Context("on a native system", func() {
-			It("reports seccomp as supported", func() {
-				// This test assumes we're running on a native system (not in an
-				// emulated container). In CI/CD environments, this should be true.
-				features, err := sysfeat.Fetch()
-				Expect(err).NotTo(HaveOccurred())
-
-				// If we're not in a container, seccomp should always be supported
-				// We can check this by verifying we're not in a container
-				// (no /.dockerenv file)
-				_, dockerEnvErr := os.Stat("/.dockerenv")
-				if os.IsNotExist(dockerEnvErr) {
-					// Not in a container, seccomp should be supported
-					Expect(features.SeccompSupported).To(BeTrue())
-				}
-			})
-		})
-	})
-
-	Describe("Architecture detection", func() {
-		It("correctly identifies the current architecture", func() {
-			// This is more of a smoke test to ensure the architecture
-			// detection doesn't panic or return unexpected values
-			goArch := runtime.GOARCH
-			Expect(goArch).NotTo(BeEmpty())
-
-			// Common architectures we expect
-			validArchs := []string{"amd64", "386", "arm64", "arm"}
-			Expect(validArchs).To(ContainElement(goArch))
 		})
 	})
 })


### PR DESCRIPTION
* this change is to support using the Docker CPI on Apple Silicon
* disables seccomp if binary arch does not match kernel arch
* should only apply to containerized environments
* used Cursor to make this change

may not actually want to merge this, but keeping it around for visibility

related to https://github.com/cloudfoundry/bosh-deployment/issues/497