### PR TITLE
Add core_file_size limit for core dump support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -60,11 +60,12 @@ directory of your job.
 
 #### `limits` Schema
 
-| **Property** | **Type** | **Required** | **Description**                                                                                                             |
-|--------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------|
-| `memory`     | string   | No           | The memory limit to apply to this process. It is formatted as a number and then a single character for units e.g. 1G, 256M. |
-| `open_files` | int      | No           | The number of files this process is allowed to have open at any one time.                                                   |
-| `processes`  | int      | No           | The number of processes which this process is allowed to have running at any one moment (inclusive of the main process).    |
+| **Property** | **Type** | **Required** | **Description**                                                                                                                 |
+|--------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `memory`         | string   | No           | The memory limit to apply to this process. It is formatted as a number and then a single character for units e.g. 1G, 256M. |
+| `open_files`     | int      | No           | The number of files this process is allowed to have open at any one time.                                                   |
+| `processes`      | int      | No           | The number of processes which this process is allowed to have running at any one moment (inclusive of the main process).    |
+| `core_file_size` | int      | No           | The maximum size (in bytes) of a core dump file. Set to enable core dump generation for post-mortem debugging.              |
 
 #### `unsafe` Schema
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -60,7 +60,7 @@ container will be written to `/var/vcap/sys/log/JOB` in the host system.
 ## Resource Limits
 
 bpm can enforce various [resource limits][limits] on your processes. There are
-currently 3 different types: memory, open files, and processes.
+currently 4 different types: memory, open files, processes, and core file size.
 
 ### Memory
 
@@ -81,6 +81,32 @@ This setting places a limit on the number of PIDs which your process is allowed
 to create. This is to protect against fork-bombs and other resource exhaustion
 mistakes or attacks. Threads also count towards this limit as they are
 also given PIDs.
+
+### Core File Size
+
+This setting controls the maximum size of core dump files produced when a
+process crashes. It is equivalent to setting `ulimit -c` for your process. By
+default the limit is zero, which means core dumps are disabled. Setting this
+value allows operators to capture core dumps for post-mortem debugging.
+
+To enable core dumps you also need to ensure the following:
+
+* **Writable working directory:** The kernel writes core dumps to the path
+  configured in `/proc/sys/kernel/core_pattern` (which often defaults to
+  `core`, i.e. the process's current working directory). In bpm the default
+  working directory is the job directory (`/var/vcap/jobs/JOB`), which is
+  mounted read-only. Set `workdir` to a writable location (e.g.
+  `/var/vcap/data/JOB` with `ephemeral_disk: true`) or configure
+  `core_pattern` on the host to point to a writable path.
+* **`fs.suid_dumpable` sysctl:** Because bpm switches from root to the `vcap`
+  user, the kernel may clear the "dumpable" flag on the process. The host
+  sysctl `fs.suid_dumpable` must be set to `1` or `2` for core dumps to work.
+  This is a host-level setting and should be configured in the BOSH
+  `pre-start` script (see [Setting Sysctl Kernel Parameters][sysctl]).
+* **Disk space:** Core dumps can be as large as the process's virtual memory.
+  Make sure the target disk has enough free space.
+
+[sysctl]: config.md#setting-sysctl-kernel-parameters
 
 [limits]: config.md#limits-schema
 

--- a/jobs/test-server/templates/bpm.yml.erb
+++ b/jobs/test-server/templates/bpm.yml.erb
@@ -10,6 +10,7 @@ processes:
     memory: 743M
     open_files: 2444
     processes: 503
+    core_file_size: 1073741824
   ephemeral_disk: true
   persistent_disk: true
   additional_volumes:

--- a/src/bpm/acceptance/bpm_acceptance_test.go
+++ b/src/bpm/acceptance/bpm_acceptance_test.go
@@ -273,6 +273,21 @@ var _ = Describe("BpmAcceptance", func() {
 
 			Expect(limits.OpenFiles).To(Equal("2444"), "RLIMIT_NOFILE should match bpm.yml open_files: 2444")
 		})
+
+		It("enforces the configured core_file_size limit", func() {
+			resp, err := client.Get(fmt.Sprintf("%s/resource-limits", *agentURI))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close() //nolint:errcheck
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var limits struct {
+				CoreFileSize string `json:"core_file_size"`
+			}
+			Expect(json.NewDecoder(resp.Body).Decode(&limits)).To(Succeed())
+
+			Expect(limits.CoreFileSize).To(Equal("1073741824"), "RLIMIT_CORE should match bpm.yml core_file_size: 1073741824")
+		})
 	})
 })
 

--- a/src/bpm/acceptance/fixtures/test-server/handlers/resource_limits.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/resource_limits.go
@@ -23,12 +23,14 @@ import (
 )
 
 type resourceLimitsResponse struct {
-	OpenFiles string `json:"open_files"`
+	OpenFiles    string `json:"open_files"`
+	CoreFileSize string `json:"core_file_size"`
 }
 
 func ResourceLimits(w http.ResponseWriter, r *http.Request) {
 	resp := resourceLimitsResponse{
-		OpenFiles: readOpenFilesLimit(),
+		OpenFiles:    readOpenFilesLimit(),
+		CoreFileSize: readCoreFileSizeLimit(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -40,6 +42,14 @@ func ResourceLimits(w http.ResponseWriter, r *http.Request) {
 func readOpenFilesLimit() string {
 	var rlimit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return fmt.Sprintf("%d", rlimit.Max)
+}
+
+func readCoreFileSizeLimit() string {
+	var rlimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_CORE, &rlimit); err != nil {
 		return fmt.Sprintf("error: %v", err)
 	}
 	return fmt.Sprintf("%d", rlimit.Max)

--- a/src/bpm/config/job_config.go
+++ b/src/bpm/config/job_config.go
@@ -49,9 +49,10 @@ type ProcessConfig struct {
 }
 
 type Limits struct {
-	Memory    *string `yaml:"memory"`
-	OpenFiles *uint64 `yaml:"open_files"`
-	Processes *int64  `yaml:"processes"`
+	Memory       *string `yaml:"memory"`
+	OpenFiles    *uint64 `yaml:"open_files"`
+	Processes    *int64  `yaml:"processes"`
+	CoreFileSize *uint64 `yaml:"core_file_size"`
 }
 
 type Hooks struct {

--- a/src/bpm/config/job_config_test.go
+++ b/src/bpm/config/job_config_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Config", func() {
 
 			expectedMemoryLimit := "100G"
 			expectedOpenFilesLimit := uint64(100)
+			expectedCoreDumpLimit := uint64(1073741824)
 
 			Expect(cfg.Processes).To(HaveLen(3))
 
@@ -53,6 +54,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Processes[0].Env).To(HaveKeyWithValue("BAZ", "BUZZ"))
 			Expect(cfg.Processes[0].Limits.Memory).To(Equal(&expectedMemoryLimit))
 			Expect(cfg.Processes[0].Limits.OpenFiles).To(Equal(&expectedOpenFilesLimit))
+			Expect(cfg.Processes[0].Limits.CoreFileSize).To(Equal(&expectedCoreDumpLimit))
 			Expect(cfg.Processes[0].AdditionalVolumes).To(ConsistOf(
 				config.Volume{Path: "/var/vcap/data/program/foobar", Writable: true},
 				config.Volume{Path: "/var/vcap/data/alternate-program"},

--- a/src/bpm/config/testdata/example.yml
+++ b/src/bpm/config/testdata/example.yml
@@ -11,6 +11,7 @@ processes:
   limits:
     memory: 100G
     open_files: 100
+    core_file_size: 1073741824
   additional_volumes:
   - path: /var/vcap/data/program/foobar
     writable: true

--- a/src/bpm/integration/bash_test.go
+++ b/src/bpm/integration/bash_test.go
@@ -57,6 +57,12 @@ wait $child;
 start_file_leak`, path)
 }
 
+const coreFileSizeBash = `trap 'kill -9 $child' SIGTERM;
+echo "core_file_size=$(ulimit -c)";
+sleep 100 &
+child=$!;
+wait $child`
+
 const processLeakBash = `trap 'kill -9 $child' SIGTERM;
 sleep 100 &
 child=$!;

--- a/src/bpm/integration/resource_limits_test.go
+++ b/src/bpm/integration/resource_limits_test.go
@@ -115,4 +115,24 @@ var _ = Describe("resource limits", func() {
 			Eventually(fileContents(stderr)).Should(ContainSubstring("fork: retry: Resource temporarily unavailable"))
 		})
 	})
+
+	Context("core file size", func() {
+		BeforeEach(func() {
+			limit := uint64(1048576)
+			cfg = newJobConfig(job, coreFileSizeBash)
+			cfg.Processes[0].Limits = &config.Limits{CoreFileSize: &limit}
+		})
+
+		It("sets the core file size rlimit", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			<-session.Exited
+
+			Expect(session).To(gexec.Exit(0))
+
+			Eventually(func() specs.ContainerState { return runcState(runcRoot, containerID).Status }).Should(Equal(specs.StateRunning))
+			Expect(runcCommand(runcRoot, "kill", containerID).Run()).To(Succeed())
+			Eventually(fileContents(stdout)).Should(ContainSubstring("core_file_size=1024"))
+		})
+	})
 })

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -290,6 +290,10 @@ func (a *RuncAdapter) BuildSpec(
 		if procCfg.Limits.OpenFiles != nil {
 			specbuilder.Apply(spec, specbuilder.WithOpenFileLimit(*procCfg.Limits.OpenFiles))
 		}
+
+		if procCfg.Limits.CoreFileSize != nil {
+			specbuilder.Apply(spec, specbuilder.WithCoreFileSizeLimit(*procCfg.Limits.CoreFileSize))
+		}
 	}
 
 	if procCfg.Unsafe == nil || !procCfg.Unsafe.HostPidNamespace {

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -782,6 +782,28 @@ var _ = Describe("RuncAdapter", func() {
 				})
 			})
 
+			Context("CoreFileSize", func() {
+				var expectedCoreFileSize uint64
+
+				BeforeEach(func() {
+					expectedCoreFileSize = 4096
+					procCfg.Limits.CoreFileSize = &expectedCoreFileSize
+				})
+
+				It("sets the rlimit on the process", func() {
+					spec, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(spec.Process.Rlimits).To(ConsistOf([]specs.POSIXRlimit{
+						{
+							Type: "RLIMIT_CORE",
+							Hard: expectedCoreFileSize,
+							Soft: expectedCoreFileSize,
+						},
+					}))
+				})
+			})
+
 			Context("Pids", func() {
 				var pidLimit int64
 

--- a/src/bpm/runc/specbuilder/specbuilder.go
+++ b/src/bpm/runc/specbuilder/specbuilder.go
@@ -185,6 +185,16 @@ func WithOpenFileLimit(limit uint64) SpecOption {
 	}
 }
 
+func WithCoreFileSizeLimit(limit uint64) SpecOption {
+	return func(spec *specs.Spec) {
+		spec.Process.Rlimits = append(spec.Process.Rlimits, specs.POSIXRlimit{
+			Type: "RLIMIT_CORE",
+			Hard: limit,
+			Soft: limit,
+		})
+	}
+}
+
 var RootUser = specs.User{
 	UID: 0,
 	GID: 0,


### PR DESCRIPTION
Allow operators to configure RLIMIT_CORE via bpm.yml so that crashed processes can produce core dumps for post-mortem debugging. Without this, the default core file size limit of zero silently prevents core dump generation, making it harder to diagnose process crashes in production.