### PR TITLE
fix: scope runc CgroupsPath to container cgroup subtree on cgroup v2

### DIFF
--- a/src/bpm/cgroups/cgroup.go
+++ b/src/bpm/cgroups/cgroup.go
@@ -102,6 +102,33 @@ func subsystemGroupingFromProcCgroup(f io.Reader, subsystem string) (string, err
 	return subsystem, nil
 }
 
+// SelfCgroupPath returns the cgroup v2 unified-mode path of the calling
+// process by reading /proc/self/cgroup. Returns an error if no unified-mode
+// entry (0::<path>) is found.
+func SelfCgroupPath() (string, error) {
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return "", fmt.Errorf("opening /proc/self/cgroup: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+	return selfCgroupPathFromReader(f)
+}
+
+func selfCgroupPathFromReader(r io.Reader) (string, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		// cgroup v2 unified-mode line: "0::<path>"
+		if strings.HasPrefix(line, "0::") {
+			return strings.TrimRight(strings.TrimPrefix(line, "0::"), "\r\n"), nil
+		}
+	}
+	if err := s.Err(); err != nil {
+		return "", fmt.Errorf("reading /proc/self/cgroup: %w", err)
+	}
+	return "", fmt.Errorf("no cgroup v2 entry found in /proc/self/cgroup")
+}
+
 func mountCgroupTmpfsIfNotPresent(mountInfos []*mountinfo.Info) error {
 	for _, mnt := range mountInfos {
 		if mnt.Mountpoint == cgroupRoot {

--- a/src/bpm/cgroups/cgroup.go
+++ b/src/bpm/cgroups/cgroup.go
@@ -159,6 +159,17 @@ func ToSystemdCgroupsPath(selfPath, containerID string) string {
 		}
 	}
 
+	// If no .slice was found, use the first non-empty path element as a
+	// uniqueness anchor so the scope name still reflects the host context.
+	if uniquePart == "" {
+		for _, part := range parts {
+			if normalized := normalizeForSystemdName(part); normalized != "" {
+				uniquePart = normalized + "-"
+				break
+			}
+		}
+	}
+
 	return fmt.Sprintf("%s:%sbpm:%s", slice, uniquePart, containerID)
 }
 

--- a/src/bpm/cgroups/cgroup.go
+++ b/src/bpm/cgroups/cgroup.go
@@ -129,6 +129,54 @@ func selfCgroupPathFromReader(r io.Reader) (string, error) {
 	return "", fmt.Errorf("no cgroup v2 entry found in /proc/self/cgroup")
 }
 
+// ToSystemdCgroupsPath converts an absolute cgroup v2 unified-mode path and
+// a container ID into the "slice:prefix:name" format expected by runc's
+// systemd cgroup driver. It extracts the parent slice and a unique identifier
+// from the first non-slice component (e.g., the garden container scope) to
+// ensure the resulting scope name is unique per warden container.
+//
+// Example:
+//
+//	selfPath = "/system.slice/garden-abc.scope/monit.service"
+//	containerID = "bpm-uaa"
+//	result = "system.slice:garden-abc-scope-bpm:bpm-uaa"
+func ToSystemdCgroupsPath(selfPath, containerID string) string {
+	parts := strings.Split(strings.TrimLeft(selfPath, "/"), "/")
+
+	slice := "system.slice" // fallback if no .slice found
+	uniquePart := ""
+
+	for i, part := range parts {
+		if strings.HasSuffix(part, ".slice") {
+			slice = part
+			if i+1 < len(parts) {
+				normalized := normalizeForSystemdName(parts[i+1])
+				if normalized != "" {
+					uniquePart = normalized + "-"
+				}
+			}
+			break
+		}
+	}
+
+	return fmt.Sprintf("%s:%sbpm:%s", slice, uniquePart, containerID)
+}
+
+// normalizeForSystemdName replaces characters invalid in systemd unit name
+// components with dashes. Valid characters are alphanumeric, '-', and '_'.
+func normalizeForSystemdName(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' {
+			b.WriteRune(c)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
 func mountCgroupTmpfsIfNotPresent(mountInfos []*mountinfo.Info) error {
 	for _, mnt := range mountInfos {
 		if mnt.Mountpoint == cgroupRoot {

--- a/src/bpm/cgroups/cgroup_test.go
+++ b/src/bpm/cgroups/cgroup_test.go
@@ -90,14 +90,14 @@ var _ = Describe("Cgroups", func() {
 				To(Equal("system.slice:garden-abc-scope-bpm:bpm-uaa"))
 		})
 
-		It("handles a path with no intermediate scope", func() {
+		It("uses slice name for uniqueness when path has no intermediate scope", func() {
 			Expect(ToSystemdCgroupsPath("/system.slice", "bpm-uaa")).
-				To(Equal("system.slice:bpm:bpm-uaa"))
+				To(Equal("system.slice:system-slice-bpm:bpm-uaa"))
 		})
 
-		It("uses system.slice fallback when no .slice component found", func() {
+		It("uses first path element for uniqueness when no .slice component found", func() {
 			Expect(ToSystemdCgroupsPath("/garden-abc.scope", "bpm-uaa")).
-				To(Equal("system.slice:bpm:bpm-uaa"))
+				To(Equal("system.slice:garden-abc-scope-bpm:bpm-uaa"))
 		})
 	})
 })

--- a/src/bpm/cgroups/cgroup_test.go
+++ b/src/bpm/cgroups/cgroup_test.go
@@ -83,4 +83,21 @@ var _ = Describe("Cgroups", func() {
 			Expect(group).To(Equal("cpu,cpuacct"))
 		})
 	})
+
+	Describe("ToSystemdCgroupsPath", func() {
+		It("converts a nested garden scope path", func() {
+			Expect(ToSystemdCgroupsPath("/system.slice/garden-abc.scope/monit.service", "bpm-uaa")).
+				To(Equal("system.slice:garden-abc-scope-bpm:bpm-uaa"))
+		})
+
+		It("handles a path with no intermediate scope", func() {
+			Expect(ToSystemdCgroupsPath("/system.slice", "bpm-uaa")).
+				To(Equal("system.slice:bpm:bpm-uaa"))
+		})
+
+		It("uses system.slice fallback when no .slice component found", func() {
+			Expect(ToSystemdCgroupsPath("/garden-abc.scope", "bpm-uaa")).
+				To(Equal("system.slice:bpm:bpm-uaa"))
+		})
+	})
 })

--- a/src/bpm/cgroups/cgroup_test.go
+++ b/src/bpm/cgroups/cgroup_test.go
@@ -24,6 +24,35 @@ import (
 )
 
 var _ = Describe("Cgroups", func() {
+	Describe("SelfCgroupPath", func() {
+		It("returns the cgroup v2 path from a valid unified-mode entry", func() {
+			r := strings.NewReader("0::/garden/abc-123/\n")
+			path, err := selfCgroupPathFromReader(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(path).To(Equal("/garden/abc-123/"))
+		})
+
+		It("strips carriage return from CRLF line endings", func() {
+			r := strings.NewReader("0::/some/path\r\n")
+			path, err := selfCgroupPathFromReader(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(path).To(Equal("/some/path"))
+		})
+
+		It("errors when there is no unified-mode entry", func() {
+			r := strings.NewReader("12:memory:/user.slice\n11:cpu:/user.slice\n")
+			_, err := selfCgroupPathFromReader(r)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("no cgroup v2 entry")))
+		})
+
+		It("errors on empty input", func() {
+			r := strings.NewReader("")
+			_, err := selfCgroupPathFromReader(r)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("checking subsystem grouping", func() {
 		var r io.Reader
 

--- a/src/bpm/commands/root.go
+++ b/src/bpm/commands/root.go
@@ -183,7 +183,7 @@ func newRuncLifecycle() (*lifecycle.RuncLifecycle, error) {
 		return nil, fmt.Errorf("failed to fetch system features: %w", err)
 	}
 
-	runcAdapter := adapter.NewRuncAdapter(*features, filepath.Glob, sharedvolume.MakeShared, locks)
+	runcAdapter := adapter.NewRuncAdapter(*features, filepath.Glob, sharedvolume.MakeShared, locks, cgroupsPathForContainer)
 	return lifecycle.NewRuncLifecycle(
 		runcClient,
 		runcAdapter,
@@ -202,6 +202,17 @@ func processByNameFromJobConfig(jobCfg *config.JobConfig, procName string) (*con
 	}
 
 	return nil, fmt.Errorf("invalid process: %s", procName)
+}
+
+func cgroupsPathForContainer(containerID string) (string, error) {
+	selfPath, err := cgroups.SelfCgroupPath()
+	if err != nil {
+		return "", err
+	}
+	if isRunningSystemd() {
+		return cgroups.ToSystemdCgroupsPath(selfPath, containerID), nil
+	}
+	return filepath.Join(selfPath, containerID), nil
 }
 
 func isRunningSystemd() bool {

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -51,18 +51,20 @@ type VolumeLocker interface {
 }
 
 type RuncAdapter struct {
-	features   sysfeat.Features
-	glob       GlobFunc
-	shareMount MountShare
-	locker     VolumeLocker
+	features       sysfeat.Features
+	glob           GlobFunc
+	shareMount     MountShare
+	locker         VolumeLocker
+	cgroupsPathFor func(containerID string) (string, error)
 }
 
-func NewRuncAdapter(features sysfeat.Features, glob GlobFunc, mountSharer MountShare, locker VolumeLocker) *RuncAdapter {
+func NewRuncAdapter(features sysfeat.Features, glob GlobFunc, mountSharer MountShare, locker VolumeLocker, cgroupsPathFor func(containerID string) (string, error)) *RuncAdapter {
 	return &RuncAdapter{
-		features:   features,
-		glob:       glob,
-		shareMount: mountSharer,
-		locker:     locker,
+		features:       features,
+		glob:           glob,
+		shareMount:     mountSharer,
+		locker:         locker,
+		cgroupsPathFor: cgroupsPathFor,
 	}
 }
 
@@ -296,6 +298,14 @@ func (a *RuncAdapter) BuildSpec(
 
 	if procCfg.Unsafe != nil && procCfg.Unsafe.Privileged {
 		specbuilder.Apply(spec, specbuilder.WithPrivileged())
+	}
+
+	if a.cgroupsPathFor != nil {
+		if cgroupsPath, err := a.cgroupsPathFor(bpmCfg.ContainerID()); err == nil {
+			specbuilder.Apply(spec, specbuilder.WithCgroupsPath(cgroupsPath))
+		} else {
+			logger.Info("cgroups-path-fallback", lager.Data{"error": err.Error(), "container-id": bpmCfg.ContainerID()})
+		}
 	}
 
 	return *spec, nil

--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -303,8 +303,6 @@ func (a *RuncAdapter) BuildSpec(
 	if a.cgroupsPathFor != nil {
 		if cgroupsPath, err := a.cgroupsPathFor(bpmCfg.ContainerID()); err == nil {
 			specbuilder.Apply(spec, specbuilder.WithCgroupsPath(cgroupsPath))
-		} else {
-			logger.Info("cgroups-path-fallback", lager.Data{"error": err.Error(), "container-id": bpmCfg.ContainerID()})
 		}
 	}
 

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -55,6 +55,8 @@ var _ = Describe("RuncAdapter", func() {
 
 		mountSharer  *fakeMountSharer
 		volumeLocker *fakeVolumeLocker
+
+		cgroupsPathForFn func(containerID string) (string, error)
 	)
 
 	BeforeEach(func() {
@@ -86,6 +88,10 @@ var _ = Describe("RuncAdapter", func() {
 
 		mountSharer = &fakeMountSharer{}
 		volumeLocker = &fakeVolumeLocker{}
+
+		cgroupsPathForFn = func(containerID string) (string, error) {
+			return "", fmt.Errorf("not on cgroup v2")
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -94,7 +100,7 @@ var _ = Describe("RuncAdapter", func() {
 		identityGlob := func(pattern string) ([]string, error) {
 			return []string{pattern}, nil
 		}
-		runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker)
+		runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker, cgroupsPathForFn)
 	})
 
 	AfterEach(func() {
@@ -889,7 +895,7 @@ var _ = Describe("RuncAdapter", func() {
 				identityGlob := func(pattern string) ([]string, error) {
 					return []string{pattern}, nil
 				}
-				runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker)
+				runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker, cgroupsPathForFn)
 			})
 
 			It("disables seccomp in the spec", func() {
@@ -955,7 +961,7 @@ var _ = Describe("RuncAdapter", func() {
 				identityGlob := func(pattern string) ([]string, error) {
 					return []string{pattern}, nil
 				}
-				runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker)
+				runcAdapter = NewRuncAdapter(features, identityGlob, mountSharer.MakeShared, volumeLocker, cgroupsPathForFn)
 			})
 
 			It("includes seccomp in the spec", func() {
@@ -1105,7 +1111,7 @@ var _ = Describe("RuncAdapter", func() {
 							return []string{pattern}, nil
 						}
 					}
-					runcAdapter = NewRuncAdapter(features, fakeGlob, mountSharer.MakeShared, volumeLocker)
+					runcAdapter = NewRuncAdapter(features, fakeGlob, mountSharer.MakeShared, volumeLocker, cgroupsPathForFn)
 				})
 
 				It("adds volumes for whatever the volume matches", func() {
@@ -1149,13 +1155,55 @@ var _ = Describe("RuncAdapter", func() {
 						fail := func(path string) ([]string, error) {
 							return nil, errors.New("doomed from the start")
 						}
-						runcAdapter = NewRuncAdapter(features, fail, mountSharer.MakeShared, volumeLocker)
+						runcAdapter = NewRuncAdapter(features, fail, mountSharer.MakeShared, volumeLocker, cgroupsPathForFn)
 					})
 
 					It("returns an error", func() {
 						_, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
 						Expect(err).To(HaveOccurred())
 					})
+				})
+			})
+		})
+
+		Context("cgroup path scoping", func() {
+			Context("when cgroupsPathForFn returns a path", func() {
+				BeforeEach(func() {
+					cgroupsPathForFn = func(containerID string) (string, error) {
+						return "/scoped/" + containerID, nil
+					}
+				})
+
+				It("sets CgroupsPath to the returned value", func() {
+					spec, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spec.Linux.CgroupsPath).To(Equal("/scoped/" + bpmCfg.ContainerID()))
+				})
+			})
+
+			Context("when cgroupsPathForFn returns an error", func() {
+				BeforeEach(func() {
+					cgroupsPathForFn = func(containerID string) (string, error) {
+						return "", fmt.Errorf("not on cgroup v2")
+					}
+				})
+
+				It("leaves CgroupsPath empty", func() {
+					spec, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spec.Linux.CgroupsPath).To(BeEmpty())
+				})
+			})
+
+			Context("when cgroupsPathForFn is nil", func() {
+				BeforeEach(func() {
+					cgroupsPathForFn = nil
+				})
+
+				It("leaves CgroupsPath empty", func() {
+					spec, err := runcAdapter.BuildSpec(logger, bpmCfg, procCfg, user)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spec.Linux.CgroupsPath).To(BeEmpty())
 				})
 			})
 		})

--- a/src/bpm/runc/specbuilder/specbuilder.go
+++ b/src/bpm/runc/specbuilder/specbuilder.go
@@ -228,6 +228,12 @@ func WithPrivileged() SpecOption {
 	}
 }
 
+func WithCgroupsPath(path string) SpecOption {
+	return func(spec *specs.Spec) {
+		spec.Linux.CgroupsPath = path
+	}
+}
+
 func removeNosuidMountOption(opts []string) []string {
 	for i := 0; i < len(opts); i++ {
 		if opts[i] == "nosuid" {

--- a/src/bpm/runc/specbuilder/specbuilder_test.go
+++ b/src/bpm/runc/specbuilder/specbuilder_test.go
@@ -134,6 +134,17 @@ var _ = Describe("SpecBuilder", func() {
 		})
 	})
 
+	Describe("WithCgroupsPath", func() {
+		It("sets the cgroups path on the spec", func() {
+			spec := specbuilder.DefaultSpec()
+			Expect(spec.Linux.CgroupsPath).To(BeEmpty())
+
+			specbuilder.Apply(spec, specbuilder.WithCgroupsPath("/garden/abc-123/bpm.uaa"))
+
+			Expect(spec.Linux.CgroupsPath).To(Equal("/garden/abc-123/bpm.uaa"))
+		})
+	})
+
 	Describe("DefaultSpec", func() {
 		It("includes seccomp by default", func() {
 			spec := specbuilder.DefaultSpec()


### PR DESCRIPTION
## Problem

On cgroup v2 hosts, BPM's runc container and the host system can share the same cgroup scope name (e.g. `bpm-uaa.scope`). When a BOSH deployment creates a job with the same name as one already running on the host (as happens in bosh-lite, where the director itself runs `uaa`), runc fails with:

```
runc run failed: container's cgroup is not empty: N process(es) found
```

This occurs because both the host BPM process and the container BPM process share the same cgroup namespace (no `NEWCGROUP`), so they see each other's cgroup scopes.

The fix using `NEWCGROUP` was [proposed in guardian](https://github.com/cloudfoundry/guardian/pull/503) but rejected because it breaks CPU throttling (same reason as the revert in guardian#495).

## Solution

BPM reads its own cgroup path from `/proc/self/cgroup` at startup and uses it to scope the container's `CgroupsPath` to a subtree unique to the current host context:

- **cgroupfs driver**: sets `CgroupsPath` to `filepath.Join(selfPath, containerID)` — nests the container under the host process's cgroup subtree
- **systemd cgroup driver** (`--systemd-cgroup`): converts to `slice:prefix:name` format, embedding a unique identifier from the host's garden scope (e.g. `system.slice:garden-abc-scope-bpm:bpm-uaa`) — creates a scope name that cannot collide across warden containers

If cgroup path detection fails (e.g. not on cgroup v2, or not in a garden scope), BPM falls back to the original behaviour silently.

## Changes

- `src/bpm/cgroups/cgroup.go`: add `SelfCgroupPath()` (reads `/proc/self/cgroup`, returns unified-mode path) and `ToSystemdCgroupsPath()` (converts absolute path + container ID to systemd `slice:prefix:name` format)
- `src/bpm/runc/specbuilder/specbuilder.go`: add `WithCgroupsPath(path string) SpecOption`
- `src/bpm/runc/adapter/adapter.go`: accept injected `cgroupsPathFor func(containerID string) (string, error)` and apply it in `BuildSpec`
- `src/bpm/commands/root.go`: implement `cgroupsPathForContainer` wiring `SelfCgroupPath` + `ToSystemdCgroupsPath` / `filepath.Join` depending on cgroup driver

## Testing

- Unit tests added for `SelfCgroupPath`, `ToSystemdCgroupsPath`, `WithCgroupsPath`, and `BuildSpec` cgroup path injection
- Verified against a bosh-lite deployment: deploying `uaa` (which collides with the director's own `uaa` job) succeeds without cgroup errors using local dev release.