### PR TITLE
fix: make cgroup acceptance test robust to runc scope naming

### DIFF
--- a/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"bpm/jobid"
 )
 
 type cgroupLimitsResponse struct {
@@ -45,21 +47,21 @@ func CgroupLimits(w http.ResponseWriter, r *http.Request) {
 		job = "test-server"
 	}
 
-	// Build the runc scope name that bpm uses.
-	// Main process: runc-bpm-<job>.scope
-	// Named process: runc-bpm-<job>.2e<process>.scope
-	var scopeName string
-	if process == "" || process == job {
-		scopeName = fmt.Sprintf("runc-bpm-%s.scope", job)
-	} else {
-		scopeName = fmt.Sprintf("runc-bpm-%s.2e%s.scope", job, process)
+	// Build the container ID exactly the way bpm does (config.BPMConfig.ContainerID):
+	// the bare job name for the main process, or "<job>.<process>" for a named
+	// process, run through jobid.Encode. Reusing jobid.Encode keeps this in sync
+	// if the encoding ever changes.
+	name := job
+	if process != "" && process != job {
+		name = fmt.Sprintf("%s.%s", job, process)
 	}
+	containerID := jobid.Encode(name)
 
-	cgroupDir, err := findCgroupDir("/sys/fs/cgroup", scopeName)
+	cgroupDir, err := findCgroupDir("/sys/fs/cgroup", containerID)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(cgroupLimitsResponse{ //nolint:errcheck
-			Error: fmt.Sprintf("could not find cgroup dir for scope %s: %v", scopeName, err),
+			Error: fmt.Sprintf("could not find cgroup dir for container %s: %v", containerID, err),
 		})
 		return
 	}
@@ -74,17 +76,29 @@ func CgroupLimits(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp) //nolint:errcheck
 }
 
-// findCgroupDir walks the cgroup filesystem looking for a directory with the
-// given scope name. Returns the full path to the scope directory.
-func findCgroupDir(root, scopeName string) (string, error) {
+// findCgroupDir walks the cgroup filesystem looking for the cgroup directory
+// for the given bpm container ID. It handles two naming conventions:
+//
+//   - cgroupfs mode (cgroup v2 without systemd): a directory named exactly
+//     containerID, e.g. "bpm-test-server"
+//   - systemd mode: a scope directory whose name ends with "-<containerID>.scope",
+//     e.g. "runc-bpm-test-server.scope" (legacy) or
+//     "garden-abc-scope-bpm-bpm-test-server.scope" (cgroup-v2-aware naming)
+//
+// Returns the full path to the matching directory.
+func findCgroupDir(root, containerID string) (string, error) {
+	scopeSuffix := "-" + containerID + ".scope"
 	var found string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if d.IsDir() && d.Name() == scopeName {
-			found = path
-			return filepath.SkipAll
+		if d.IsDir() {
+			name := d.Name()
+			if name == containerID || strings.HasSuffix(name, scopeSuffix) {
+				found = path
+				return filepath.SkipAll
+			}
 		}
 		return nil
 	})
@@ -92,7 +106,7 @@ func findCgroupDir(root, scopeName string) (string, error) {
 		return "", err
 	}
 	if found == "" {
-		return "", fmt.Errorf("scope %s not found under %s", scopeName, root)
+		return "", fmt.Errorf("no cgroup dir found for container %s under %s", containerID, root)
 	}
 	return found, nil
 }

--- a/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits_test.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits_test.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2017-Present CloudFoundry.org Foundation, Inc. All rights reserved.
+//
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handlers Suite")
+}
+
+var _ = Describe("findCgroupDir", func() {
+	var root string
+
+	BeforeEach(func() {
+		var err error
+		root, err = os.MkdirTemp("", "cgroup-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(root)).To(Succeed())
+	})
+
+	Context("legacy systemd mode (runc default scope name)", func() {
+		It("finds runc-bpm-test-server.scope", func() {
+			scopeDir := filepath.Join(root, "system.slice", "runc-bpm-test-server.scope")
+			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
+
+			found, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(scopeDir))
+		})
+	})
+
+	Context("cgroup-v2-aware systemd mode (scope name from ToSystemdCgroupsPath)", func() {
+		It("finds a scope with a warden garden prefix ending in -bpm-test-server.scope", func() {
+			scopeDir := filepath.Join(root, "system.slice", "garden-abc-scope-bpm-bpm-test-server.scope")
+			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
+
+			found, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(scopeDir))
+		})
+
+		It("finds a scope with a monit-service prefix", func() {
+			scopeDir := filepath.Join(root, "system.slice", "bpm-service-bpm-bpm-test-server.scope")
+			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
+
+			found, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(scopeDir))
+		})
+	})
+
+	Context("cgroupfs mode (cgroup v2 without systemd)", func() {
+		It("finds a directory named exactly containerID", func() {
+			cgroupDir := filepath.Join(root, "docker", "abc123", "bpm-test-server")
+			Expect(os.MkdirAll(cgroupDir, 0755)).To(Succeed())
+
+			found, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(cgroupDir))
+		})
+	})
+
+	Context("named process", func() {
+		It("finds the scope for a named process using the .2e encoding", func() {
+			scopeDir := filepath.Join(root, "system.slice", "runc-bpm-test-server.2ealt-server.scope")
+			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
+
+			found, err := findCgroupDir(root, "bpm-test-server.2ealt-server")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(scopeDir))
+		})
+	})
+
+	Context("not found", func() {
+		It("returns an error when no matching directory exists", func() {
+			_, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("bpm-test-server"))
+		})
+
+		It("does not match a directory that only partially matches the container ID", func() {
+			wrongDir := filepath.Join(root, "bpm-test-server-extra")
+			Expect(os.MkdirAll(wrongDir, 0755)).To(Succeed())
+
+			_, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("does not match a scope for a different container", func() {
+			wrongScope := filepath.Join(root, "system.slice", "runc-bpm-other-server.scope")
+			Expect(os.MkdirAll(wrongScope, 0755)).To(Succeed())
+
+			_, err := findCgroupDir(root, "bpm-test-server")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This is fixing CI after #219. Oddly there are some green builds with #219 that we can't explain, but the majority of them are red. They're red because the test server can't find the container to check if limits have been applied correctly.

The CgroupLimits test-server handler hardcoded the runc default scope name (runc-bpm-<job>.scope). Since the cgroup-v2-aware CgroupsPath fix (f8e0e295), runc derives the scope name from the self cgroup path, so it varies by environment (e.g. docker-bpm-bpm-<job>.scope), causing test-acceptance-noble to fail when cgroup v2 is delegated into the BOSH VM.

findCgroupDir now matches on the bpm container ID, accepting both the cgroupfs leaf directory (named exactly containerID) and any systemd scope ending in -<containerID>.scope. The container ID is built via jobid.Encode to stay in sync with config.BPMConfig.ContainerID. Adds unit tests covering the legacy, cgroup-v2-aware, cgroupfs, named-process, and negative cases.

