### PR TITLE
fix: eliminate stale or concurrent container interference

### DIFF
--- a/src/bpm/acceptance/bpm_acceptance_test.go
+++ b/src/bpm/acceptance/bpm_acceptance_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -293,18 +294,19 @@ var _ = Describe("BpmAcceptance", func() {
 
 var _ = Describe("CgroupLimits", func() {
 	BeforeEach(func() {
+		Expect(*agentURI).NotTo(BeEmpty(), "-agent-uri must be provided")
 		Expect(*observerURI).NotTo(BeEmpty(), "-observer-uri must be provided")
 	})
 
 	It("sets the correct memory limit on test-server", func() {
-		limits := getCgroupLimits("test-server")
+		limits := getCgroupLimits()
 		// 743M = 743 * 1024 * 1024 = 779091968
 		Expect(limits.MemoryMax).To(Equal("779091968"),
 			"memory cgroup limit should match bpm.yml memory: 743M (cgroup_dir: %s)", limits.CgroupDir)
 	})
 
 	It("sets the correct pids limit on test-server", func() {
-		limits := getCgroupLimits("test-server")
+		limits := getCgroupLimits()
 		Expect(limits.PidsMax).To(Equal("503"),
 			"pids cgroup limit should match bpm.yml processes: 503 (cgroup_dir: %s)", limits.CgroupDir)
 	})
@@ -342,8 +344,17 @@ type cgroupLimitsResult struct {
 	Error     string `json:"error,omitempty"`
 }
 
-func getCgroupLimits(process string) cgroupLimitsResult {
-	resp, err := client.Get(fmt.Sprintf("%s/cgroup-limits?process=%s", *observerURI, process))
+// getCgroupLimits reads cgroup limits for the test-server using a two-step approach:
+//  1. Ask the test-server for its own live cgroup v2 path via /self-cgroup-path.
+//     The path is unique per Docker container ID — it never matches stale scopes
+//     from previous builds or scopes from concurrent builds on the same worker.
+//  2. Pass that exact path to the privileged observer's /cgroup-limits endpoint,
+//     which reads memory.max and pids.max directly without any directory search.
+func getCgroupLimits() cgroupLimitsResult {
+	cgroupPath := fetchSelfCgroupPath()
+
+	resp, err := client.Get(fmt.Sprintf("%s/cgroup-limits?cgroup-path=%s",
+		*observerURI, url.QueryEscape(cgroupPath)))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -353,6 +364,26 @@ func getCgroupLimits(process string) cgroupLimitsResult {
 	ExpectWithOffset(1, json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
 	ExpectWithOffset(1, result.Error).To(BeEmpty(), "cgroup-limits returned error: %s", result.Error)
 	return result
+}
+
+// fetchSelfCgroupPath retrieves the test-server's own cgroup v2 unified-mode
+// path via /self-cgroup-path. Fails the test if the endpoint returns an error
+// (e.g. on cgroup v1 systems where there is no 0:: entry in /proc/self/cgroup).
+func fetchSelfCgroupPath() string {
+	resp, err := client.Get(fmt.Sprintf("%s/self-cgroup-path", *agentURI))
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	defer resp.Body.Close() //nolint:errcheck
+
+	ExpectWithOffset(1, resp.StatusCode).To(Equal(http.StatusOK))
+
+	var result struct {
+		CgroupV2Path string `json:"cgroup_v2_path"`
+		Error        string `json:"error,omitempty"`
+	}
+	ExpectWithOffset(1, json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+	ExpectWithOffset(1, result.Error).To(BeEmpty(), "self-cgroup-path returned error: %s", result.Error)
+	ExpectWithOffset(1, result.CgroupV2Path).NotTo(BeEmpty(), "self-cgroup-path returned empty path")
+	return result.CgroupV2Path
 }
 
 func containsString(list []string, item string) bool {

--- a/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits.go
@@ -16,14 +16,14 @@
 package handlers
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"bpm/jobid"
 )
 
 type cgroupLimitsResponse struct {
@@ -33,82 +33,99 @@ type cgroupLimitsResponse struct {
 	Error     string `json:"error,omitempty"`
 }
 
-// CgroupLimits reads cgroup limit files for a given bpm process by searching
-// the host's /sys/fs/cgroup filesystem. This handler is intended to run in a
-// privileged bpm container that has /sys/fs/cgroup mounted.
+type selfCgroupPathResponse struct {
+	CgroupV2Path string `json:"cgroup_v2_path,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// SelfCgroupPath returns the cgroup v2 unified-mode path of the calling
+// process by reading /proc/self/cgroup. The returned path is relative to the
+// cgroup root (e.g. "/docker/CONTAINERID/system.slice/monit-service-bpm-bpm-test-server.scope").
+// Callers pass this to the privileged observer's CgroupLimits as the cgroup-path
+// parameter to read limits from the exact live cgroup.
+func SelfCgroupPath(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		if encErr := json.NewEncoder(w).Encode(selfCgroupPathResponse{
+			Error: fmt.Sprintf("open /proc/self/cgroup: %v", err),
+		}); encErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+	defer f.Close() //nolint:errcheck
+
+	path, err := parseCgroupV2Path(f)
+	if err != nil {
+		if encErr := json.NewEncoder(w).Encode(selfCgroupPathResponse{Error: err.Error()}); encErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+	if err := json.NewEncoder(w).Encode(selfCgroupPathResponse{CgroupV2Path: path}); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+// parseCgroupV2Path reads a /proc/<pid>/cgroup-format stream and returns the
+// cgroup v2 unified-mode path — the entry whose hierarchy ID is 0 (format: "0::<path>").
+func parseCgroupV2Path(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "0::") {
+			return strings.TrimPrefix(line, "0::"), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading cgroup file: %w", err)
+	}
+	return "", fmt.Errorf("no cgroup v2 unified-mode entry (0::<path>) in /proc/self/cgroup")
+}
+
+// CgroupLimits reads cgroup limit files from an exact path previously obtained
+// from the target process via SelfCgroupPath. This handler is intended to run
+// in a privileged bpm container that has /sys/fs/cgroup mounted.
 //
 // Query params:
-//   - process: the bpm process name (e.g. "test-server", "alt-test-server")
-//   - job: the bpm job name (default: "test-server")
+//   - cgroup-path: the cgroup v2 path returned by SelfCgroupPath on the target
+//     process (e.g. "/docker/CONTAINERID/system.slice/monit-service-bpm-bpm-test-server.scope").
+//     Reading from the live process's own path avoids stale-cgroup and
+//     concurrent-build interference entirely.
 func CgroupLimits(w http.ResponseWriter, r *http.Request) {
-	process := r.URL.Query().Get("process")
-	job := r.URL.Query().Get("job")
-	if job == "" {
-		job = "test-server"
-	}
+	w.Header().Set("Content-Type", "application/json")
 
-	// Build the container ID exactly the way bpm does (config.BPMConfig.ContainerID):
-	// the bare job name for the main process, or "<job>.<process>" for a named
-	// process, run through jobid.Encode. Reusing jobid.Encode keeps this in sync
-	// if the encoding ever changes.
-	name := job
-	if process != "" && process != job {
-		name = fmt.Sprintf("%s.%s", job, process)
-	}
-	containerID := jobid.Encode(name)
-
-	cgroupDir, err := findCgroupDir("/sys/fs/cgroup", containerID)
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(cgroupLimitsResponse{ //nolint:errcheck
-			Error: fmt.Sprintf("could not find cgroup dir for container %s: %v", containerID, err),
-		})
+	exactPath := r.URL.Query().Get("cgroup-path")
+	if exactPath == "" {
+		if err := json.NewEncoder(w).Encode(cgroupLimitsResponse{
+			Error: "cgroup-path query parameter is required",
+		}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 		return
 	}
 
-	resp := cgroupLimitsResponse{
+	// Canonicalize before use so that sequences like "/../etc" in exactPath
+	// cannot escape the cgroup root.
+	const cgroupRoot = "/sys/fs/cgroup"
+	cgroupDir := filepath.Clean(cgroupRoot + exactPath)
+	if cgroupDir != cgroupRoot && !strings.HasPrefix(cgroupDir, cgroupRoot+"/") {
+		if err := json.NewEncoder(w).Encode(cgroupLimitsResponse{
+			Error: fmt.Sprintf("cgroup-path %q escapes the cgroup root", exactPath),
+		}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+	if err := json.NewEncoder(w).Encode(cgroupLimitsResponse{
 		CgroupDir: cgroupDir,
 		MemoryMax: readCgroupValue(cgroupDir, "memory.max"),
 		PidsMax:   readCgroupValue(cgroupDir, "pids.max"),
+	}); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp) //nolint:errcheck
-}
-
-// findCgroupDir walks the cgroup filesystem looking for the cgroup directory
-// for the given bpm container ID. It handles two naming conventions:
-//
-//   - cgroupfs mode (cgroup v2 without systemd): a directory named exactly
-//     containerID, e.g. "bpm-test-server"
-//   - systemd mode: a scope directory whose name ends with "-<containerID>.scope",
-//     e.g. "runc-bpm-test-server.scope" (legacy) or
-//     "garden-abc-scope-bpm-bpm-test-server.scope" (cgroup-v2-aware naming)
-//
-// Returns the full path to the matching directory.
-func findCgroupDir(root, containerID string) (string, error) {
-	scopeSuffix := "-" + containerID + ".scope"
-	var found string
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			name := d.Name()
-			if name == containerID || strings.HasSuffix(name, scopeSuffix) {
-				found = path
-				return filepath.SkipAll
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-	if found == "" {
-		return "", fmt.Errorf("no cgroup dir found for container %s under %s", containerID, root)
-	}
-	return found, nil
 }
 
 func readCgroupValue(dir, filename string) string {

--- a/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits_test.go
+++ b/src/bpm/acceptance/fixtures/test-server/handlers/cgroup_limits_test.go
@@ -16,106 +16,101 @@
 package handlers
 
 import (
-	"os"
-	"path/filepath"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+func init() {
+	// ginkgo -r (recursive) passes all flags from the outer acceptance suite to
+	// every discovered sub-package. Define them here (unused) so that
+	// flag.Parse() does not fail with "flag provided but not defined".
+	flag.String("agent-uri", "", "unused in handlers unit tests")
+	flag.String("observer-uri", "", "unused in handlers unit tests")
+}
+
 func TestHandlers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Handlers Suite")
 }
 
-var _ = Describe("findCgroupDir", func() {
-	var root string
+var _ = Describe("CgroupLimits path traversal guard", func() {
+	callHandler := func(cgroupPath string) cgroupLimitsResponse {
+		req := httptest.NewRequest(http.MethodGet, "/cgroup-limits?cgroup-path="+cgroupPath, nil)
+		rec := httptest.NewRecorder()
+		CgroupLimits(rec, req)
+		var resp cgroupLimitsResponse
+		Expect(json.NewDecoder(rec.Body).Decode(&resp)).To(Succeed())
+		return resp
+	}
 
-	BeforeEach(func() {
-		var err error
-		root, err = os.MkdirTemp("", "cgroup-test-*")
+	DescribeTable("rejects paths that escape /sys/fs/cgroup",
+		func(traversal string) {
+			resp := callHandler(traversal)
+			Expect(resp.Error).To(ContainSubstring("escapes the cgroup root"),
+				"path %q should be rejected", traversal)
+		},
+		Entry("parent traversal", "/../etc"),
+		Entry("double traversal", "/docker/abc/../../etc"),
+		Entry("URL-decoded traversal kept by Go query parsing", "/valid/../../../etc"),
+	)
+
+	It("accepts a well-formed absolute path inside the cgroup root", func() {
+		// The path won't exist on the test host so memory.max will error, but
+		// the traversal guard must not reject it.
+		resp := callHandler("/docker/abc123/system.slice/monit-service-bpm-bpm-test-server.scope")
+		Expect(resp.Error).NotTo(ContainSubstring("escapes"))
+	})
+})
+
+var _ = Describe("parseCgroupV2Path", func() {
+	It("returns the cgroup v2 unified-mode path", func() {
+		input := strings.NewReader("12:blkio:/\n0::/docker/abc123/system.slice/monit.service\n")
+		path, err := parseCgroupV2Path(input)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/docker/abc123/system.slice/monit.service"))
 	})
 
-	AfterEach(func() {
-		Expect(os.RemoveAll(root)).To(Succeed())
+	It("ignores v1 hierarchy entries and returns the 0:: entry", func() {
+		input := strings.NewReader(
+			"11:memory:/docker/abc123\n" +
+				"10:cpu,cpuacct:/docker/abc123\n" +
+				"0::/docker/abc123/system.slice/monit-service-bpm-bpm-test-server.scope\n",
+		)
+		path, err := parseCgroupV2Path(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/docker/abc123/system.slice/monit-service-bpm-bpm-test-server.scope"))
 	})
 
-	Context("legacy systemd mode (runc default scope name)", func() {
-		It("finds runc-bpm-test-server.scope", func() {
-			scopeDir := filepath.Join(root, "system.slice", "runc-bpm-test-server.scope")
-			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
-
-			found, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(Equal(scopeDir))
-		})
+	It("returns an error when there is no 0:: entry", func() {
+		input := strings.NewReader("11:memory:/foo\n10:cpu:/foo\n")
+		_, err := parseCgroupV2Path(input)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("0::"))
 	})
 
-	Context("cgroup-v2-aware systemd mode (scope name from ToSystemdCgroupsPath)", func() {
-		It("finds a scope with a warden garden prefix ending in -bpm-test-server.scope", func() {
-			scopeDir := filepath.Join(root, "system.slice", "garden-abc-scope-bpm-bpm-test-server.scope")
-			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
-
-			found, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(Equal(scopeDir))
-		})
-
-		It("finds a scope with a monit-service prefix", func() {
-			scopeDir := filepath.Join(root, "system.slice", "bpm-service-bpm-bpm-test-server.scope")
-			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
-
-			found, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(Equal(scopeDir))
-		})
+	It("returns an error for an empty file", func() {
+		_, err := parseCgroupV2Path(strings.NewReader(""))
+		Expect(err).To(HaveOccurred())
 	})
 
-	Context("cgroupfs mode (cgroup v2 without systemd)", func() {
-		It("finds a directory named exactly containerID", func() {
-			cgroupDir := filepath.Join(root, "docker", "abc123", "bpm-test-server")
-			Expect(os.MkdirAll(cgroupDir, 0755)).To(Succeed())
-
-			found, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(Equal(cgroupDir))
-		})
+	It("handles a pure cgroup v2 system where 0:: is the only entry", func() {
+		input := strings.NewReader("0::/user.slice/user-1000.slice/session-1.scope\n")
+		path, err := parseCgroupV2Path(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/user.slice/user-1000.slice/session-1.scope"))
 	})
 
-	Context("named process", func() {
-		It("finds the scope for a named process using the .2e encoding", func() {
-			scopeDir := filepath.Join(root, "system.slice", "runc-bpm-test-server.2ealt-server.scope")
-			Expect(os.MkdirAll(scopeDir, 0755)).To(Succeed())
-
-			found, err := findCgroupDir(root, "bpm-test-server.2ealt-server")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(Equal(scopeDir))
-		})
-	})
-
-	Context("not found", func() {
-		It("returns an error when no matching directory exists", func() {
-			_, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("bpm-test-server"))
-		})
-
-		It("does not match a directory that only partially matches the container ID", func() {
-			wrongDir := filepath.Join(root, "bpm-test-server-extra")
-			Expect(os.MkdirAll(wrongDir, 0755)).To(Succeed())
-
-			_, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("does not match a scope for a different container", func() {
-			wrongScope := filepath.Join(root, "system.slice", "runc-bpm-other-server.scope")
-			Expect(os.MkdirAll(wrongScope, 0755)).To(Succeed())
-
-			_, err := findCgroupDir(root, "bpm-test-server")
-			Expect(err).To(HaveOccurred())
-		})
+	It("handles a path of / (container at the cgroup root)", func() {
+		input := strings.NewReader("0::/\n")
+		path, err := parseCgroupV2Path(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/"))
 	})
 })

--- a/src/bpm/acceptance/fixtures/test-server/main.go
+++ b/src/bpm/acceptance/fixtures/test-server/main.go
@@ -62,6 +62,7 @@ func main() {
 	http.HandleFunc("/syslog", handlers.Syslog)
 	http.HandleFunc("/resource-limits", handlers.ResourceLimits)
 	http.HandleFunc("/cgroup-limits", handlers.CgroupLimits)
+	http.HandleFunc("/self-cgroup-path", handlers.SelfCgroupPath)
 	http.HandleFunc("/spawn-processes", handlers.SpawnProcesses)
 
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
The CI build was usually failing but intermittently passing after #219. This was because 1) the vm's /sys/fs/cgroup gets mapped into containers wholesale these days and 2) there were some stale containers on a worker which when present met the test criteria of a container named test-server with 743MB.

Replace the name-based cgroup directory search (findCgroupDir) with an exact-path approach: a new /self-cgroup-path endpoint reads the test-server's own /proc/self/cgroup and returns the cgroup v2 unified-mode path. That path is unique per Docker container ID, so it can never match a stale scope from a previous run or a scope owned by a concurrent build on the same worker. The privileged observer's /cgroup-limits endpoint now accepts cgroup-path and reads memory.max / pids.max directly from that path — no filesystem walk needed.

also fixed a problem where the new unit tests for the test server were hanging because of a flag parsing issue